### PR TITLE
feat(telemetry): add unique compound index on deviceId and timestamp

### DIFF
--- a/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
+++ b/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
@@ -1,6 +1,8 @@
 package com.p2ps.telemetry.model;
 
 import java.time.Instant;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
@@ -19,6 +21,7 @@ public class TelemetryRecord {
     @Id
     private String id;
 
+    @NotNull
     private String deviceId;
 
     private String storeId;
@@ -29,6 +32,7 @@ public class TelemetryRecord {
     private Double lng;
     private Double accuracyMeters;
 
+    @NotNull
     private Long timestamp;
 
     @Indexed(expireAfter = "94608000s")

--- a/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
+++ b/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
@@ -6,16 +6,14 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Data
 @Document(collection = "telemetry_records")
-@CompoundIndexes({
-        @CompoundIndex(def = "{'storeId': 1, 'itemId': 1}"),
-        @CompoundIndex(name = "unique_device_timestamp", def = "{'deviceId': 1, 'timestamp': 1}", unique = true)
-})
+@CompoundIndex(def = "{'storeId': 1, 'itemId': 1}")
+@CompoundIndex(name = "unique_device_timestamp", def = "{'deviceId': 1, 'timestamp': 1}", unique = true)
+
 public class TelemetryRecord {
 
     @Id

--- a/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
+++ b/src/main/java/com/p2ps/telemetry/model/TelemetryRecord.java
@@ -4,12 +4,16 @@ import java.time.Instant;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Data
 @Document(collection = "telemetry_records")
-@CompoundIndex(def = "{'storeId': 1, 'itemId': 1}")
+@CompoundIndexes({
+        @CompoundIndex(def = "{'storeId': 1, 'itemId': 1}"),
+        @CompoundIndex(name = "unique_device_timestamp", def = "{'deviceId': 1, 'timestamp': 1}", unique = true)
+})
 public class TelemetryRecord {
 
     @Id
@@ -17,10 +21,8 @@ public class TelemetryRecord {
 
     private String deviceId;
 
-    @Indexed
     private String storeId;
 
-    @Indexed
     private String itemId;
 
     private Double lat;
@@ -29,6 +31,6 @@ public class TelemetryRecord {
 
     private Long timestamp;
 
-    @Indexed(expireAfter = "94608000s") //expires after 3 years
+    @Indexed(expireAfter = "94608000s")
     private Instant serverReceivedTimestamp;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+spring.data.mongodb.auto-index-creation=true
+
 spring.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/p2p_shopping}
 telemetry.api.key=${TELEMETRY_API_KEY:default-telemetry-key}
 app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
+++ b/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
@@ -153,4 +153,30 @@ class TelemetryServiceTest {
         assertEquals(1, result.size());
         assertEquals("pasta", ReflectionTestUtils.getField(result.getFirst(), "itemId"));
     }
+
+    @Test
+    void shouldHandleDuplicateKeyExceptionOnPingWithoutThrowing() {
+        TelemetryPingDTO dto = buildPingDto();
+        doThrow(new org.springframework.dao.DuplicateKeyException("duplicate key: deviceId + timestamp"))
+                .when(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldHandleDuplicateKeyExceptionOnBatchWithoutThrowing() {
+        TelemetryBatchDTO batchDTO = new TelemetryBatchDTO();
+        ReflectionTestUtils.setField(batchDTO, "pings", List.of(buildPingDto()));
+        doThrow(new org.springframework.dao.DuplicateKeyException("duplicate key: deviceId + timestamp"))
+                .when(telemetryRepository).insert(org.mockito.ArgumentMatchers.anyList());
+
+        telemetryService.processBatch(batchDTO);
+
+        verify(telemetryRepository).insert(org.mockito.ArgumentMatchers.anyList());
+    }
+
+
+
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -14,7 +14,7 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # Use in-memory simple cache for tests to avoid depending on external Redis
 spring.cache.type=simple
 
-# MongoDB - can be overridden via SPRING_MONGODB_URI env var for integration tests with real MongoDB
+# MongoDB - can be overridden via SPRING_DATA_MONGODB_URI env var for integration tests with real MongoDB
 spring.mongodb.uri=${SPRING_DATA_MONGODB_URI:mongodb://localhost:27017/test_db}
 
 server.port=8081

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -15,7 +15,7 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.cache.type=simple
 
 # MongoDB - can be overridden via SPRING_MONGODB_URI env var for integration tests with real MongoDB
-spring.mongodb.uri=${SPRING_MONGODB_URI:mongodb://mock-address:27017/test}
+spring.mongodb.uri=${SPRING_DATA_MONGODB_URI:mongodb://localhost:27017/test_db}
 
 server.port=8081
 


### PR DESCRIPTION
## Description
Implements a unique compound index on `deviceId + timestamp` in the `telemetry_records` MongoDB collection to prevent duplicate data when the mobile client retries a failed request. Also removes simple indexes on `storeId` and `itemId` to improve bulk insert performance at high volume.

## Changes

### TelemetryRecord.java
- Replaced single `@CompoundIndex` with `@CompoundIndexes` to support multiple compound indexes
- Added unique compound index on `deviceId + timestamp` to prevent duplicate pings from mobile retries
- Removed `@Indexed` simple annotations from `storeId` and `itemId` fields (redundant since compound index on `storeId + itemId` already exists)

### application.properties
- Added `spring.data.mongodb.auto-index-creation=true` to allow Spring Boot to automatically create indexes defined in the model on startup

### TelemetryServiceTest.java
- Added `shouldHandleDuplicateKeyExceptionOnPingWithoutThrowing` test to verify the service handles duplicate ping gracefully
- Added `shouldHandleDuplicateKeyExceptionOnBatchWithoutThrowing` test to verify the service handles duplicate batch gracefully

## MongoDB Atlas
- Verified that `unique_device_timestamp` index was created successfully on Atlas after startup
- Verified that simple indexes on `storeId` and `itemId` were removed from Atlas

## Notes
- Existing duplicate documents in `telemetry_records` had to be cleared before the unique index could be created
- Auto-index creation is enabled via `spring.data.mongodb.auto-index-creation=true`

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry ingestion now tolerates duplicate-key conflicts, preventing failures on duplicate submissions.
  * Added non-null validation for device ID and timestamp to reduce invalid records.

* **Improvements**
  * Refined indexing strategy (including a unique device+timestamp index) for more reliable and faster lookups.
  * Enabled automatic index creation at startup.

* **Tests**
  * Added unit tests covering duplicate-record handling in telemetry processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->