### PR TITLE
fix: auth token conditional

### DIFF
--- a/src/main/java/com/p2ps/auth/controller/AuthController.java
+++ b/src/main/java/com/p2ps/auth/controller/AuthController.java
@@ -51,7 +51,12 @@ public class AuthController {
         }
         String email = auth.getName();
         return userService.findByEmail(email)
-                .map(user -> ResponseEntity.ok(toUserResponse(user)))
+                .map(user -> {
+                    String token = jwtUtil.generateToken(email, user.getTokenVersion());
+                    Map<String, Object> response = toUserResponse(user);
+                    response.put("token", token);
+                    return ResponseEntity.ok(response);
+                })
                 .orElseGet(() -> {
                     logger.warn("Authenticated user record not found in database.");
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -83,10 +88,7 @@ public class AuthController {
                     ResponseCookie cookie = createJwtCookie(token, 24L * 60 * 60, servletRequest.isSecure());
                     Map<String, Object> data = toUserResponse(user);
                     
-                    if ("true".equalsIgnoreCase(servletRequest.getHeader("X-Return-Token"))) {
-                        data.put("token", token);
-                    }
-                    
+                    data.put("token", token);
                     data.put("message", "Login successful");
                     return ResponseEntity.ok()
                             .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/p2ps/auth/controller/AuthController.java
+++ b/src/main/java/com/p2ps/auth/controller/AuthController.java
@@ -44,7 +44,8 @@ public class AuthController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<Map<String, Object>> me() {
+    public ResponseEntity<Map<String, Object>> me(
+            @RequestHeader(value = "X-Return-Token", required = false) String returnToken) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -54,7 +55,9 @@ public class AuthController {
                 .map(user -> {
                     String token = jwtUtil.generateToken(email, user.getTokenVersion());
                     Map<String, Object> response = toUserResponse(user);
-                    response.put("token", token);
+                    if ("true".equalsIgnoreCase(returnToken)) {
+                        response.put("token", token);
+                    }
                     return ResponseEntity.ok(response);
                 })
                 .orElseGet(() -> {
@@ -75,7 +78,10 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody LoginRequest request, HttpServletRequest servletRequest) {
+    public ResponseEntity<Map<String, Object>> login(
+            @Valid @RequestBody LoginRequest request,
+            @RequestHeader(value = "X-Return-Token", required = false) String returnToken,
+            HttpServletRequest servletRequest) {
         Authentication auth = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
         );
@@ -87,8 +93,10 @@ public class AuthController {
                     String token = jwtUtil.generateToken(principalName, user.getTokenVersion());
                     ResponseCookie cookie = createJwtCookie(token, 24L * 60 * 60, servletRequest.isSecure());
                     Map<String, Object> data = toUserResponse(user);
-                    
-                    data.put("token", token);
+
+                    if ("true".equalsIgnoreCase(returnToken)) {
+                        data.put("token", token);
+                    }
                     data.put("message", "Login successful");
                     return ResponseEntity.ok()
                             .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/p2ps/auth/controller/AuthController.java
+++ b/src/main/java/com/p2ps/auth/controller/AuthController.java
@@ -53,9 +53,9 @@ public class AuthController {
         String email = auth.getName();
         return userService.findByEmail(email)
                 .map(user -> {
-                    String token = jwtUtil.generateToken(email, user.getTokenVersion());
                     Map<String, Object> response = toUserResponse(user);
                     if ("true".equalsIgnoreCase(returnToken)) {
+                        String token = jwtUtil.generateToken(email, user.getTokenVersion());
                         response.put("token", token);
                     }
                     return ResponseEntity.ok(response);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/api/auth/me` and `/api/auth/login` endpoints now accept an optional `X-Return-Token` header. When set to `"true"`, the endpoints will include an authentication token in the response payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->