### PR TITLE
206 -telemetry data retention

### DIFF
--- a/src/main/java/com/p2ps/P2PShoppingApplication.java
+++ b/src/main/java/com/p2ps/P2PShoppingApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
 @EnableCaching
+@EnableScheduling
 public class P2PShoppingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/p2ps/ai/controller/AiController.java
+++ b/src/main/java/com/p2ps/ai/controller/AiController.java
@@ -1,29 +1,70 @@
 package com.p2ps.ai.controller;
 
-import com.p2ps.ai.dto.RecipeRequest;
-import com.p2ps.ai.dto.ParsedItemResponse;
+import com.p2ps.ai.dto.AiGenerationResponse;
 import com.p2ps.ai.service.AiOrchestrationService;
-import jakarta.validation.Valid;
+import com.p2ps.util.ImageValidationUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
-import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/ai")
 public class AiController {
 
     private final AiOrchestrationService aiOrchestrationService;
+    private final ImageValidationUtil imageValidator;
+    private static final String ERROR_KEY = "error";
 
-    public AiController(AiOrchestrationService aiOrchestrationService) {
+    public AiController(AiOrchestrationService aiOrchestrationService, ImageValidationUtil imageValidator) {
         this.aiOrchestrationService = aiOrchestrationService;
+        this.imageValidator=imageValidator;
     }
 
+    /**
+     * @deprecated Use {@link #generateListMultimodal(MultipartFile, String, Principal)} instead.
+     * Scheduled for removal in version 3.0.0.
+     */
+    @Deprecated(since = "2.1", forRemoval = true)
     @PostMapping("/recipe-to-list")
-    public ResponseEntity<List<ParsedItemResponse>> parseRecipe(@Valid @RequestBody RecipeRequest request, Principal principal) {
-        String userEmail = principal.getName();
-        List<ParsedItemResponse> response = aiOrchestrationService.processRecipeAndPopulateList(request, userEmail);
+    public ResponseEntity<Map<String, String>> parseRecipe() {
+        return ResponseEntity.status(HttpStatus.GONE)
+                .header("Deprecation", "true")
+                .body(Map.of(
+                        ERROR_KEY, "This endpoint is permanently removed due to the new Gatekeeper architecture.",
+                        "migration", "Please use the multimodal /api/ai/generate endpoint."
+                ));
+    }
+
+    // New multimodal endpoint
+    @PostMapping(value = "/generate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Object> generateListMultimodal(
+            @RequestParam(value = "image", required = false) MultipartFile image,
+            @RequestParam(value = "text", required = false) String text,
+            Principal principal) {
+
+        // Has to send at least text or image
+        if ((image == null || image.isEmpty()) && (text == null || text.trim().isEmpty())) {
+            return ResponseEntity.badRequest().body(Map.of(ERROR_KEY, "You have to send a text or an image."));
+        }
+
+        // If image was sent, we validate using external util
+        if (image != null && !image.isEmpty()) {
+            String format = imageValidator.detectImageFormat(image);
+            if (format == null || (!format.equalsIgnoreCase("jpeg") && !format.equalsIgnoreCase("jpg") && !format.equalsIgnoreCase("png"))) {
+                return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                        .body(Map.of(ERROR_KEY, "Invalid file. Only JPEG and PNG images allowed."));
+            }
+        }
+
+        // Send data towards Orchestrator for AI processing
+        // (Gatekeeper returns a response directly, not saving anything in database)
+        AiGenerationResponse response = aiOrchestrationService.generateShoppingItems(image, text);
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/p2ps/ai/dto/AiGenerationResponse.java
+++ b/src/main/java/com/p2ps/ai/dto/AiGenerationResponse.java
@@ -1,0 +1,13 @@
+package com.p2ps.ai.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class AiGenerationResponse {
+    // AI list type: "RECIPE", "FREQUENT" or "NORMAL"
+    private String listType;
+
+    // List of parsed items
+    private List<ParsedItemResponse> items;
+}

--- a/src/main/java/com/p2ps/ai/dto/ParsedItemResponse.java
+++ b/src/main/java/com/p2ps/ai/dto/ParsedItemResponse.java
@@ -1,10 +1,15 @@
 package com.p2ps.ai.dto;
 
 import lombok.Data;
+import java.util.UUID;
 
 @Data
 public class ParsedItemResponse {
-   private String name;
+   private String genericName;  // ex: lapte
+   private String specificName; // ex: Lapte Zuzu 1.5%
+   private String brand;        // ex: Zuzu
    private Double quantity;
    private String unit;
+   private UUID catalogId;      // ID-ul din baza de date catalog
+   private String category;     // ex: Lactate
 }

--- a/src/main/java/com/p2ps/ai/dto/RecipeRequest.java
+++ b/src/main/java/com/p2ps/ai/dto/RecipeRequest.java
@@ -1,4 +1,5 @@
 package com.p2ps.ai.dto;
+//OBSOLETE since we dont use just JSON text anymore
 
 import lombok.Data;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/p2ps/ai/service/AiOrchestrationService.java
+++ b/src/main/java/com/p2ps/ai/service/AiOrchestrationService.java
@@ -3,11 +3,13 @@ package com.p2ps.ai.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.p2ps.ai.dto.AiGenerationResponse;
 import com.p2ps.ai.dto.ParsedItemResponse;
 import com.p2ps.ai.dto.RecipeRequest;
 import com.p2ps.exception.AiProcessingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,12 +27,13 @@ public class AiOrchestrationService {
         this.objectMapper = objectMapper.orElseGet(ObjectMapper::new);
     }
 
+    //Legacy parsing method
     public List<ParsedItemResponse> processRecipeAndPopulateList(RecipeRequest request, String userEmail) {
         List<ParsedItemResponse> parsedItems = parseIngredientsFromText(request.getText());
 
         List<ParsedItemResponse> validItems = new ArrayList<>();
         for (ParsedItemResponse aiItem : parsedItems) {
-            if (aiItem != null && aiItem.getName() != null && !aiItem.getName().trim().isEmpty()) {
+            if (aiItem != null && aiItem.getGenericName() != null && !aiItem.getGenericName().trim().isEmpty()) {
                 validItems.add(aiItem);
             }
         }
@@ -59,5 +62,30 @@ public class AiOrchestrationService {
         }
 
         return parsedItems;
+    }
+
+    // Multimodal and Gatekeeper Flow
+    public AiGenerationResponse generateShoppingItems(MultipartFile image, String text) {
+        // Receive the generated JSON from Gemini
+        String jsonResult = geminiService.extractFromMultimodal(image, text);
+
+        // Map the JSON to the response object
+        AiGenerationResponse response;
+        try {
+            response = objectMapper.readValue(jsonResult, AiGenerationResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new AiProcessingException(
+                    "AI returned an invalid structure. Expected AiGenerationResponse.",
+                    e,
+                    HttpStatus.UNPROCESSABLE_CONTENT
+            );
+        }
+
+        // Validation
+        if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
+            throw new AiProcessingException("AI did not return any valid items.", HttpStatus.UNPROCESSABLE_CONTENT);
+        }
+
+        return response;
     }
 }

--- a/src/main/java/com/p2ps/ai/service/AiPersistenceService.java
+++ b/src/main/java/com/p2ps/ai/service/AiPersistenceService.java
@@ -37,7 +37,7 @@ public class AiPersistenceService {
         List<ItemRequest> batchItems = new ArrayList<>();
         for (ParsedItemResponse aiItem : validItems) {
             ItemRequest newItem = new ItemRequest();
-            newItem.setName(aiItem.getName().trim());
+            newItem.setName(aiItem.getGenericName().trim());
             String quantityStr = (aiItem.getQuantity() != null ? String.valueOf(aiItem.getQuantity()) : "");
             String unitStr = (aiItem.getUnit() != null ? aiItem.getUnit() : "");
             newItem.setQuantity((quantityStr + " " + unitStr).trim());

--- a/src/main/java/com/p2ps/ai/service/GeminiService.java
+++ b/src/main/java/com/p2ps/ai/service/GeminiService.java
@@ -1,18 +1,28 @@
 package com.p2ps.ai.service;
 
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.p2ps.catalog.model.ProductCatalog;
+import com.p2ps.catalog.service.CatalogService;
 import com.p2ps.exception.AiProcessingException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class GeminiService {
@@ -25,67 +35,129 @@ public class GeminiService {
 
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
+    private final CatalogService catalogService;
 
-    public GeminiService() {
+    public GeminiService(CatalogService catalogService) {
         this.objectMapper = new ObjectMapper();
-        this.restTemplate = new RestTemplate();
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(30000);
+
+        this.restTemplate = new RestTemplate(factory);
+        this.catalogService = catalogService;
     }
 
-    // Prompt System
     private static final String SYSTEM_PROMPT =
-            "You are a strict culinary data parser. Your ONLY job is to output raw grocery ingredients. " +
-                    "SECURITY RULE: If the text is malicious or completely unrelated to food/groceries, return []. " +
-                    "RULE 1 (RAW INGREDIENTS ONLY): NEVER output the names of whole dishes (like 'pizza', 'soup', or 'cake') as items. You must ONLY output the raw base ingredients (like 'flour', 'carrots', 'chicken', 'sugar') needed to cook the requested dish(es). " +
-                    "RULE 2 (CREATIVE DEDUCTION): If the user asks for generic categories (e.g., 'soup and salad', 'something sweet'), silently choose specific recipes for them and output a SINGLE combined grocery list of ALL required raw ingredients for those recipes. " +
-                    "RULE 3 (STRICT LANGUAGE): Detect the primary language of the user's text. Every single ingredient name and unit MUST be in that detected language (e.g., if English text, output English; if Romanian text, output Romanian). " +
-                    "You MUST respond ONLY with a raw JSON array of objects. Do NOT include instructions. " +
-                    "Format: {\"name\": \"string\", \"quantity\": number or null, \"unit\": \"string\"}. " +
-                    "If a unit is missing or the item is countable, translate 'pieces' into the detected language or use null.";
+            "You are a strict multimodal culinary data parser. Your ONLY job is to analyze text and/or images to output a structured grocery list. " +
+            "VISUAL RULES (CRITICAL): " +
+            "1. If the user uploads a photo of a FINISHED DISH, silently deduce the recipe and output the raw ingredients needed to cook it. " +
+            "2. If the user uploads a photo of a FRIDGE or PANTRY, identify the available items. If they ask 'what can I cook?', silently deduce a meal, and output ONLY the missing ingredients they need to buy. If they don't specify, just list all the food items you see. " +
+            "RULE 1 (RAW INGREDIENTS ONLY): NEVER output the names of whole dishes. Output ONLY the raw base ingredients needed. If the user asks for a recipe or meal idea, DO NOT REFUSE. Silently invent the recipe and output the required ingredients. " +
+            "RULE 2 (STRICT CATALOG MATCHING): Below is our 'GLOBAL CATALOG'. For EVERY ingredient you need, you MUST search this catalog first. If the ingredient exists in the catalog (e.g., you need 'milk' and 'Lapte Zuzu' is in the catalog), you MUST replace the generic item with the exact catalog item. Map it by copying the exact 'specificName', 'brand', and 'catalogId' from the catalog. Only if an item is completely missing from the catalog, use a generic name and set 'catalogId', 'specificName' and 'brand' to null. " +
+            "RULE 3 (CATEGORIZATION): Classify the ENTIRE list under ONE 'listType': 'RECIPE' (for cooking) or 'NORMAL' (for standard items). DO NOT use 'FREQUENT'. Additionally, assign each individual item a logical 'category' (e.g., 'Dairy', 'Produce', 'Cleaning'). " +
+            "RULE 4 (STRICT LANGUAGE): Detect the primary language of the user's input. The 'genericName', 'category', and 'unit' MUST be translated into that exact detected language. " +
+            "You MUST respond ONLY with a raw JSON object. Do NOT include markdown instructions. " +
+            "Format: {\"listType\": \"string\", \"items\": [{\"genericName\": \"string\", \"specificName\": \"string or null\", \"brand\": \"string or null\", \"quantity\": number or null, \"unit\": \"string or null\", \"catalogId\": \"string or null\", \"category\": \"string\"}]}.";
 
-    public String extractIngredientsAsJson(String rawRecipeText) {
-
-        String finalUrl = apiUrl;
-
-        Map<String, Object> requestBody = Map.of(
-                "contents", List.of(
-                        Map.of("parts", List.of(
-                                // Prompt + user text added
-                                Map.of("text", SYSTEM_PROMPT + "\n\nUser Text:\n" + rawRecipeText)
-                        ))
-                ),
-                // Make Gemini return JSON
-                "generationConfig", Map.of(
-                        "responseMimeType", "application/json"
-                )
-        );
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        //make apikey invisible in the url
-        headers.set("x-goog-api-key", apiKey);
-
-        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
-
+    public String extractFromMultimodal(MultipartFile image, String text) {
         try {
-            ResponseEntity<String> response = restTemplate.postForEntity(finalUrl, requestEntity, String.class);
-            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            List<ProductCatalog> popularProducts = catalogService.getTopPopularProducts();
+            String catalogContext = buildCatalogContext(popularProducts);
+            List<Map<String, Object>> parts = buildRequestParts(image, text, catalogContext);
 
-            JsonNode candidates = rootNode.path("candidates");
-            if (candidates.isMissingNode() || !candidates.isArray() || candidates.isEmpty()) {
-                throw new AiProcessingException("Google API returned an empty response or blocked the request.");
-            }
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("contents", List.of(Map.of("role", "user", "parts", parts)));
+            requestBody.put("generationConfig", Map.of("responseMimeType", "application/json"));
 
-            JsonNode parts = candidates.get(0).path("content").path("parts");
-            if (parts.isMissingNode() || !parts.isArray() || parts.isEmpty()) {
-                throw new AiProcessingException("Google API returned no text parts in the candidate.");
-            }
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("x-goog-api-key", apiKey);
 
-            return parts.get(0).path("text").asText();
+            HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(apiUrl, requestEntity, String.class);
 
+            return parseTextResponse(response.getBody());
         } catch (AiProcessingException e) {
             throw e;
         } catch (Exception e) {
-            throw new AiProcessingException("Could not communicate with Google Gemini API: " + e.getMessage(), e);
+            throw new AiProcessingException("Error during Multimodal AI processing: " + e.getMessage(), e);
         }
+    }
+
+    private String buildCatalogContext(List<ProductCatalog> popularProducts) {
+        return "=== GLOBAL CATALOG ===\n" + popularProducts.stream()
+                .map(p -> "ID: " + p.getId() + " | Generic Name: " + p.getGenericName() + " | Specific Name: " + p.getSpecificName() + " | Brand: " + (p.getBrand() != null ? p.getBrand() : "N/A"))
+                .collect(Collectors.joining("\n")) + "\n======================";
+    }
+
+    private List<Map<String, Object>> buildRequestParts(MultipartFile image, String text, String catalogContext) throws IOException {
+        List<Map<String, Object>> parts = new ArrayList<>();
+        String fallbackText = (image != null && !image.isEmpty())
+                ? "I want to cook with what's in the photo."
+                : "Please analyze the text below.";
+
+        String finalPrompt = SYSTEM_PROMPT + "\n\n" + catalogContext + "\n\nUser Text:\n" +
+                (text != null && !text.trim().isEmpty() ? text : fallbackText);
+        parts.add(Map.of("text", finalPrompt));
+
+        if (image != null && !image.isEmpty()) {
+            byte[] imageBytes = image.getBytes();
+            String secureMimeType = detectMimeTypeSecurely(imageBytes);
+            if (secureMimeType == null) {
+                throw new AiProcessingException("Unsupported or corrupted image format. Only actual JPEG/PNG files are allowed.");
+            }
+
+            parts.add(Map.of("inlineData", Map.of(
+                    "mimeType", secureMimeType,
+                    "data", Base64.getEncoder().encodeToString(imageBytes)
+            )));
+        }
+        return parts;
+    }
+
+    private String parseTextResponse(String responseBody) throws IOException {
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        JsonNode candidates = rootNode.path("candidates");
+        if (candidates.isMissingNode() || candidates.isEmpty()) {
+            throw new AiProcessingException("Google API returned an empty response.");
+        }
+
+        JsonNode responseParts = candidates.get(0).path("content").path("parts");
+        if (responseParts.isMissingNode() || responseParts.isEmpty()) {
+            throw new AiProcessingException("Google API returned candidate without text parts.");
+        }
+
+        JsonNode textNode = responseParts.get(0).path("text");
+        if (textNode.isMissingNode() || textNode.asText().trim().isEmpty()) {
+            throw new AiProcessingException("Google API returned an empty text response.");
+        }
+
+        return textNode.asText();
+    }
+
+    public String extractIngredientsAsJson(String rawRecipeText) {
+        return extractFromMultimodal(null, rawRecipeText);
+    }
+
+    private String detectMimeTypeSecurely(byte[] bytes) {
+        try (InputStream is = new ByteArrayInputStream(bytes);
+             ImageInputStream iis = ImageIO.createImageInputStream(is)) {
+            if (iis == null) return null;
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+            if (!readers.hasNext()) return null;
+
+            ImageReader reader = readers.next();
+            try {
+                String format = reader.getFormatName().toLowerCase();
+                if (format.equals("png")) return "image/png";
+                if (format.equals("jpeg") || format.equals("jpg")) return "image/jpeg";
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException _) {
+            // Return null if parsing fails
+        }
+        return null;
     }
 }

--- a/src/main/java/com/p2ps/catalog/repository/ProductCatalogRepository.java
+++ b/src/main/java/com/p2ps/catalog/repository/ProductCatalogRepository.java
@@ -46,4 +46,7 @@ public interface ProductCatalogRepository extends JpaRepository<ProductCatalog, 
                        @Param("brand") String brand, 
                        @Param("category") String category, 
                        @Param("price") BigDecimal price);
+
+    // Searches the products wher egeneric name contains the word, ignoring upper case
+    List<ProductCatalog> findByGenericNameContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/p2ps/catalog/service/CatalogService.java
+++ b/src/main/java/com/p2ps/catalog/service/CatalogService.java
@@ -47,4 +47,12 @@ public class CatalogService {
     public List<UUID> getBestStoresForCatalogProduct(UUID catalogId) {
         return catalogRepository.findBestStoresForCatalogProduct(catalogId);
     }
+
+    @Transactional(readOnly = true)
+    public List<ProductCatalog> searchProductsByName(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return List.of(); // returnează listă goală dacă AI-ul trimite null
+        }
+        return catalogRepository.findByGenericNameContainingIgnoreCase(keyword.trim());
+    }
 }

--- a/src/main/java/com/p2ps/config/RoomSubscriptionInterceptor.java
+++ b/src/main/java/com/p2ps/config/RoomSubscriptionInterceptor.java
@@ -12,6 +12,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.security.core.Authentication;
 
+import org.springframework.lang.Nullable;
 import java.security.Principal;
 import java.util.UUID;
 import java.util.regex.Pattern;

--- a/src/main/java/com/p2ps/config/StompJwtAuthInterceptor.java
+++ b/src/main/java/com/p2ps/config/StompJwtAuthInterceptor.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
+import org.springframework.lang.Nullable;
 
 import java.util.Map;
 

--- a/src/main/java/com/p2ps/lists/dto/ShoppingListDTO.java
+++ b/src/main/java/com/p2ps/lists/dto/ShoppingListDTO.java
@@ -14,4 +14,7 @@ public class ShoppingListDTO {
     private String subcategory;
     private String finalStore;
     private List<ItemDTO> items;
+    private String ownerName;
+    private String ownerEmail;
+    private String userId;
 }

--- a/src/main/java/com/p2ps/lists/service/ShoppingListService.java
+++ b/src/main/java/com/p2ps/lists/service/ShoppingListService.java
@@ -185,6 +185,12 @@ public class ShoppingListService {
         dto.setCategory(list.getCategory());
         dto.setSubcategory(list.getSubcategory());
         dto.setFinalStore(list.getFinalStore());
+        if (list.getUser() != null) {
+            dto.setUserId(list.getUser().getId() != null ? list.getUser().getId().toString() : null);
+            dto.setOwnerEmail(list.getUser().getEmail());
+            String fullName = list.getUser().getFirstName() + " " + list.getUser().getLastName();
+            dto.setOwnerName(fullName.trim());
+        }
 
         if (list.getItems() != null) {
             dto.setItems(list.getItems().stream()

--- a/src/main/java/com/p2ps/telemetry/repository/TelemetryRepository.java
+++ b/src/main/java/com/p2ps/telemetry/repository/TelemetryRepository.java
@@ -2,6 +2,7 @@ package com.p2ps.telemetry.repository;
 
 import com.p2ps.telemetry.model.TelemetryRecord;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +14,7 @@ public interface TelemetryRepository extends MongoRepository<TelemetryRecord, St
     List<TelemetryRecord> findByStoreIdAndItemId(String storeId, String itemId);
 
     Optional<TelemetryRecord> findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(String deviceId, String storeId, String itemId);
+
+    @Query(value = "{ 'timestamp': { $lt: ?0 } }", delete = true)
+    void deleteByTimestampBefore(long timestamp);
 }

--- a/src/main/java/com/p2ps/telemetry/services/TelemetryCleanupJob.java
+++ b/src/main/java/com/p2ps/telemetry/services/TelemetryCleanupJob.java
@@ -1,0 +1,33 @@
+package com.p2ps.telemetry.services;
+
+import com.p2ps.telemetry.repository.TelemetryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TelemetryCleanupJob {
+
+    private final TelemetryRepository telemetryRepository;
+
+    @Value("${telemetry.cleanup.retention-days:7}")
+    private int retentionDays;
+
+    @Scheduled(cron = "${telemetry.cleanup.cron:0 0 0 * * *}")
+    public void deleteStaleRecords() {
+        long cutoff = Instant.now()
+                .minus(retentionDays, ChronoUnit.DAYS)
+                .toEpochMilli();
+
+        log.info("[CLEANUP] Deleting telemetry records older than {} days", retentionDays);
+        telemetryRepository.deleteByTimestampBefore(cutoff);
+        log.info("[CLEANUP] Done.");
+    }
+}

--- a/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
+++ b/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
@@ -2,9 +2,11 @@ package com.p2ps.telemetry.services;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import com.p2ps.telemetry.dto.TelemetryPingDTO;
@@ -20,16 +22,31 @@ public class TelemetryService {
     private final TelemetryRepository telemetryRepository;
     private final AnomalyDetectionService anomalyDetectionService;
 
+    @Value("${telemetry.dedup.window-seconds:60}")
+    private long dedupWindowSeconds;
+
     @Async("telemetryExecutor")
     public void processPing(TelemetryPingDTO pingDTO) {
         log.info("[SERVICE] Processing ping for the product: {}", pingDTO.getItemId());
+
+        long windowStart = pingDTO.getTimestamp() - (dedupWindowSeconds * 1000);
+        Optional<TelemetryRecord> recent = telemetryRepository
+                .findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                        pingDTO.getDeviceId(), pingDTO.getStoreId(), pingDTO.getItemId());
+
+        if (recent.isPresent() && recent.get().getTimestamp() > windowStart) {
+            log.info("[SERVICE] Duplicate ping dropped for device: {}, item: {}",
+                    pingDTO.getDeviceId(), pingDTO.getItemId());
+            return;
+        }
 
         TelemetryRecord telemetryRecord = mapToEntity(pingDTO);
         anomalyDetectionService.evaluateAndSetStatus(telemetryRecord);
 
         try {
             telemetryRepository.save(telemetryRecord);
-            log.info("[SERVICE] Ping successfully saved for product: {} with status: {}", pingDTO.getItemId(), telemetryRecord.getStatus());
+            log.info("[SERVICE] Ping successfully saved for product: {} with status: {}",
+                    pingDTO.getItemId(), telemetryRecord.getStatus());
         } catch (Exception e) {
             log.error("[SERVICE] Failed to save ping: {}", e.getMessage(), e);
         }

--- a/src/main/java/com/p2ps/util/ImageValidationUtil.java
+++ b/src/main/java/com/p2ps/util/ImageValidationUtil.java
@@ -1,0 +1,32 @@
+package com.p2ps.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+@Component
+public class ImageValidationUtil {
+
+    public String detectImageFormat(MultipartFile file) {
+        try (InputStream is = file.getInputStream();
+             ImageInputStream iis = ImageIO.createImageInputStream(is)) {
+            if (iis == null) return null;
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+            if (!readers.hasNext()) return null;
+
+            ImageReader reader = readers.next();
+            try {
+                return reader.getFormatName();
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException _) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,10 @@ spring.servlet.multipart.max-request-size=5MB
 # Public OSRM demo endpoint is for light/demo use only.
 # Plan for self-hosted OSRM or managed provider for production.
 osrm.base-url=${OSRM_BASE_URL:https://router.project-osrm.org}
+
+# Telemetry data retention
+telemetry.cleanup.cron=0 0 0 * * *
+telemetry.cleanup.retention-days=7
+
+# Telemetry deduplication
+telemetry.dedup.window-seconds=60

--- a/src/test/java/com/p2ps/ai/controller/AiControllerTest.java
+++ b/src/test/java/com/p2ps/ai/controller/AiControllerTest.java
@@ -1,33 +1,139 @@
 package com.p2ps.ai.controller;
 
-import com.p2ps.ai.dto.ParsedItemResponse;
-import com.p2ps.ai.dto.RecipeRequest;
+import com.p2ps.ai.dto.AiGenerationResponse;
 import com.p2ps.ai.service.AiOrchestrationService;
+import com.p2ps.util.ImageValidationUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
-import java.util.List;
+import java.util.Map;
 
-import org.springframework.http.HttpStatus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class AiControllerTest {
 
-    private final AiOrchestrationService orchestration = mock(AiOrchestrationService.class);
-    private final AiController controller = new AiController(orchestration);
+    @Mock
+    private AiOrchestrationService orchestration;
+
+    @Mock
+    private ImageValidationUtil imageValidator;
+
+    @InjectMocks
+    private AiController controller;
+
+    private Principal principal;
+
+    @BeforeEach
+    void setUp() {
+        principal = () -> "user@test.com";
+    }
+
 
     @Test
-    void parseRecipe_callsServiceAndReturnsOk() {
-        RecipeRequest req = new RecipeRequest();
-        req.setText("recipe text");
-        ParsedItemResponse p = new ParsedItemResponse();
-        p.setName("Tomato");
-        when(orchestration.processRecipeAndPopulateList(req, "user@e")).thenReturn(List.of(p));
-        Principal principal = () -> "user@e";
-        var resp = controller.parseRecipe(req, principal);
+    @SuppressWarnings("unchecked")
+    void generateListMultimodal_whenBothInputsAreEmpty_returnsBadRequest() {
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(null, "   ", principal);
+
+        // Assert
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        assertThat((Map<String, String>) resp.getBody()).containsEntry("error", "You have to send a text or an image.");
+        verifyNoInteractions(orchestration);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void generateListMultimodal_whenImageIsInvalidFormat_returnsUnsupportedMediaType() {
+        // Arrange
+        MultipartFile image = new MockMultipartFile("image", "test.gif", "image/gif", "fake-data".getBytes());
+        when(imageValidator.detectImageFormat(image)).thenReturn("gif");
+
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(image, null, principal);
+
+        // Assert
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+
+        assertThat((Map<String, String>) resp.getBody()).containsEntry("error", "Invalid file. Only JPEG and PNG images allowed.");
+        verifyNoInteractions(orchestration);
+    }
+
+    @Test
+    void generateListMultimodal_whenImageFormatCannotBeDetected_returnsUnsupportedMediaType() {
+        // Arrange
+        MultipartFile image = new MockMultipartFile("image", "corrupted.jpg", "image/jpeg", "fake-data".getBytes());
+        when(imageValidator.detectImageFormat(image)).thenReturn(null);
+
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(image, "am si text", principal);
+
+        // Assert
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        verifyNoInteractions(orchestration);
+    }
+
+    @Test
+    void generateListMultimodal_whenValidTextOnly_returnsOk() {
+        // Arrange
+        AiGenerationResponse aiResp = new AiGenerationResponse();
+        aiResp.setListType("RECIPE");
+        when(orchestration.generateShoppingItems(null, "Valid recipe text")).thenReturn(aiResp);
+
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(null, "Valid recipe text", principal);
+
+        // Assert
         assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(resp.getBody()).hasSize(1);
-        assertThat(resp.getBody().get(0).getName()).isEqualTo("Tomato");
+        assertThat(resp.getBody()).isEqualTo(aiResp);
+
+        verify(imageValidator, never()).detectImageFormat(any());
+    }
+
+    @Test
+    void generateListMultimodal_whenValidImageAndText_returnsOk() {
+        // Arrange
+        MultipartFile image = new MockMultipartFile("image", "photo.png", "image/png", "fake-data".getBytes());
+        when(imageValidator.detectImageFormat(image)).thenReturn("png");
+
+        AiGenerationResponse aiResp = new AiGenerationResponse();
+        aiResp.setListType("FREQUENT");
+        when(orchestration.generateShoppingItems(image, "What is this?")).thenReturn(aiResp);
+
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(image, "What is this?", principal);
+
+        // Assert
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).isEqualTo(aiResp);
+        verify(imageValidator, times(1)).detectImageFormat(image);
+        verify(orchestration, times(1)).generateShoppingItems(image, "What is this?");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void generateListMultimodal_whenImageIsEmptyByteAndTextIsNull_returnsBadRequest() {
+        MultipartFile emptyImage = new MockMultipartFile("image", new byte[0]);
+
+        // Act
+        ResponseEntity<?> resp = controller.generateListMultimodal(emptyImage, null, principal);
+
+        // Assert
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        Map<String, String> body = (Map<String, String>) resp.getBody();
+        assertThat(body).containsEntry("error", "You have to send a text or an image.");
+        verifyNoInteractions(orchestration);
     }
 }

--- a/src/test/java/com/p2ps/ai/service/AiOrchestrationServiceTest.java
+++ b/src/test/java/com/p2ps/ai/service/AiOrchestrationServiceTest.java
@@ -1,13 +1,18 @@
 package com.p2ps.ai.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.p2ps.ai.dto.AiGenerationResponse;
 import com.p2ps.ai.dto.RecipeRequest;
 import com.p2ps.exception.AiProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,29 +27,26 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class AiOrchestrationServiceTest {
 
-    GeminiService geminiService = mock(GeminiService.class);
-    AiPersistenceService aiPersistenceService = mock(AiPersistenceService.class);
+    @Mock
+    private GeminiService geminiService;
 
-    @Test
-    void invalidJson_throwsAiProcessingException() {
-        AiOrchestrationService svc = new AiOrchestrationService(geminiService, aiPersistenceService, Optional.of(new ObjectMapper()));
-        when(geminiService.extractIngredientsAsJson(anyString())).thenReturn("invalid-json");
+    @Mock
+    private AiPersistenceService aiPersistenceService;
 
-        RecipeRequest req = new RecipeRequest();
-        req.setText("text");
+    private AiOrchestrationService svc;
 
-        assertThatThrownBy(() -> svc.processRecipeAndPopulateList(req, "u@e"))
-                .isInstanceOf(AiProcessingException.class);
+    @BeforeEach
+    void setUp() {
+        svc = new AiOrchestrationService(geminiService, aiPersistenceService, Optional.of(new ObjectMapper()));
     }
 
     @ParameterizedTest
     @CsvSource({
-        "'[]', 'AI did not return any valid ingredients'",
-        "'null', 'AI returned a null payload'",
-        "'', 'AI could not return a correctly structured list'"
+            "invalid-json, AI could not return a correctly structured list",
+            "'[]', AI did not return any valid ingredients",
+            "null, null payload"
     })
-    void invalidAiResponse_throwsAiProcessingException(String aiOutput, String expectedMessage) {
-        AiOrchestrationService svc = new AiOrchestrationService(geminiService, aiPersistenceService, Optional.of(new ObjectMapper()));
+    void processRecipe_fails_throwsAiProcessingException(String aiOutput, String expectedErrorMessage) {
         when(geminiService.extractIngredientsAsJson(anyString())).thenReturn(aiOutput);
 
         RecipeRequest req = new RecipeRequest();
@@ -52,13 +54,12 @@ class AiOrchestrationServiceTest {
 
         assertThatThrownBy(() -> svc.processRecipeAndPopulateList(req, "u@e"))
                 .isInstanceOf(AiProcessingException.class)
-                .hasMessageContaining(expectedMessage);
+                .hasMessageContaining(expectedErrorMessage);
     }
 
     @Test
-    void success_filtersInvalidItemsBeforePersisting() {
-        AiOrchestrationService svc = new AiOrchestrationService(geminiService, aiPersistenceService, Optional.of(new ObjectMapper()));
-        String json = "[null,{\"name\":\"   \",\"quantity\":1,\"unit\":\"pieces\"},{\"name\":\"Tomato\",\"quantity\":2,\"unit\":\"pieces\"}]";
+    void processRecipe_success_filtersInvalidItemsBeforePersisting() {
+        String json = "[null,{\"genericName\":\"   \",\"quantity\":1,\"unit\":\"pieces\"},{\"genericName\":\"Tomato\",\"quantity\":2,\"unit\":\"pieces\"}]";
         when(geminiService.extractIngredientsAsJson(anyString())).thenReturn(json);
 
         RecipeRequest req = new RecipeRequest();
@@ -70,15 +71,14 @@ class AiOrchestrationServiceTest {
         var result = svc.processRecipeAndPopulateList(req, "u@e");
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getName()).isEqualTo("Tomato");
+        assertThat(result.get(0).getGenericName()).isEqualTo("Tomato");
 
         verify(aiPersistenceService).createListAndPopulateItems(listId, "New List", List.of(result.get(0)), "u@e");
     }
 
     @Test
-    void success_delegatesToPersistenceService() {
-        AiOrchestrationService svc = new AiOrchestrationService(geminiService, aiPersistenceService, Optional.of(new ObjectMapper()));
-        String json = "[{\"name\":\"Tomato\",\"quantity\":2,\"unit\":\"pieces\"}]";
+    void processRecipe_success_delegatesToPersistenceService() {
+        String json = "[{\"genericName\":\"Tomato\",\"quantity\":2,\"unit\":\"pieces\"}]";
         when(geminiService.extractIngredientsAsJson(anyString())).thenReturn(json);
 
         RecipeRequest req = new RecipeRequest();
@@ -90,8 +90,78 @@ class AiOrchestrationServiceTest {
         var result = svc.processRecipeAndPopulateList(req, "u@e");
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getName()).isEqualTo("Tomato");
+        assertThat(result.get(0).getGenericName()).isEqualTo("Tomato");
 
         verify(aiPersistenceService).createListAndPopulateItems(eq(listId), eq("New List"), anyList(), eq("u@e"));
+    }
+
+
+    @Test
+    void generateShoppingItems_success_returnsParsedResponse() {
+        // Arrange
+        MultipartFile mockImage = new MockMultipartFile("image", "test.jpg", "image/jpeg", "data".getBytes());
+        String text = "Reteta clatite";
+        String validJson = """
+                {
+                  "listType": "RECIPE",
+                  "items": [
+                    {
+                      "genericName": "Lapte",
+                      "category": "Lactate"
+                    }
+                  ]
+                }
+                """;
+
+        when(geminiService.extractFromMultimodal(mockImage, text)).thenReturn(validJson);
+
+        // Act
+        AiGenerationResponse response = svc.generateShoppingItems(mockImage, text);
+
+        // Assert
+        assertThat(response).isNotNull();
+        assertThat(response.getListType()).isEqualTo("RECIPE");
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getGenericName()).isEqualTo("Lapte");
+
+        verifyNoInteractions(aiPersistenceService);
+    }
+
+    @Test
+    void generateShoppingItems_invalidJson_throwsAiProcessingException() {
+        when(geminiService.extractFromMultimodal(null, "text")).thenReturn("I am an AI, I cannot give you JSON.");
+
+        assertThatThrownBy(() -> svc.generateShoppingItems(null, "text"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("AI returned an invalid structure");
+    }
+
+    @Test
+    void generateShoppingItems_emptyItems_throwsAiProcessingException() {
+        String jsonWithEmptyItems = """
+                {
+                  "listType": "RECIPE",
+                  "items": []
+                }
+                """;
+        when(geminiService.extractFromMultimodal(null, "text")).thenReturn(jsonWithEmptyItems);
+
+        assertThatThrownBy(() -> svc.generateShoppingItems(null, "text"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("AI did not return any valid items");
+    }
+
+    @Test
+    void generateShoppingItems_nullItems_throwsAiProcessingException() {
+        String jsonWithNullItems = """
+                {
+                  "listType": "RECIPE"
+                }
+                """;
+        when(geminiService.extractFromMultimodal(null, "text")).thenReturn(jsonWithNullItems);
+
+        assertThatThrownBy(() -> svc.generateShoppingItems(null, "text"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("AI did not return any valid items");
     }
 }

--- a/src/test/java/com/p2ps/ai/service/AiPersistenceServiceTest.java
+++ b/src/test/java/com/p2ps/ai/service/AiPersistenceServiceTest.java
@@ -1,19 +1,25 @@
 package com.p2ps.ai.service;
 
 import com.p2ps.ai.dto.ParsedItemResponse;
+import com.p2ps.lists.dto.ItemRequest;
 import com.p2ps.lists.dto.ShoppingListDTO;
 import com.p2ps.lists.model.ListCategory;
 import com.p2ps.lists.service.ItemService;
 import com.p2ps.lists.service.ShoppingListService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,40 +37,91 @@ class AiPersistenceServiceTest {
     @InjectMocks
     private AiPersistenceService aiPersistenceService;
 
+    @Captor
+    private ArgumentCaptor<List<ItemRequest>> itemRequestCaptor;
+
     @Test
-    void createListAndPopulateItems_WithExistingList() {
+    void createList_withExistingList_skipsCreationAndMapsCorrectly() {
         // Arrange
         UUID existingListId = UUID.randomUUID();
         ParsedItemResponse item = new ParsedItemResponse();
-        item.setName("Milk");
-        item.setQuantity(1.0);
+        item.setGenericName("Milk ");
+        item.setQuantity(1.5);
         item.setUnit("L");
 
         // Act
         aiPersistenceService.createListAndPopulateItems(existingListId, null, List.of(item), "user@test.com");
 
         // Assert
-        verify(shoppingListService, never()).createList(anyString(), anyString(), any(), any()); // Nu s-a creat listă nouă
-        verify(itemService, times(1)).addItemsToList(eq(existingListId), anyList(), eq("user@test.com"));
+        verify(shoppingListService, never()).createList(anyString(), anyString(), any(), any());
+
+        verify(itemService, times(1)).addItemsToList(eq(existingListId), itemRequestCaptor.capture(), eq("user@test.com"));
+
+        List<ItemRequest> mappedItems = itemRequestCaptor.getValue();
+        assertThat(mappedItems).hasSize(1);
+
+        ItemRequest savedItem = mappedItems.getFirst();
+        assertThat(savedItem.getName()).isEqualTo("Milk"); // Trebuie să fie tăiat de trim()
+        assertThat(savedItem.getQuantity()).isEqualTo("1.5 L");
+        assertThat(savedItem.getCategory()).isEqualTo("AI Generated");
     }
 
     @Test
-    void createListAndPopulateItems_CreatesNewListWhenIdIsNull() {
+    void createList_withNullIdAndValidTitle_createsNewList() {
         // Arrange
         ParsedItemResponse item = new ParsedItemResponse();
-        item.setName("Bread");
+        item.setGenericName("Bread");
 
         UUID newListId = UUID.randomUUID();
         ShoppingListDTO mockNewList = new ShoppingListDTO();
         mockNewList.setId(newListId);
 
-        when(shoppingListService.createList(anyString(), eq("user@test.com"), eq(ListCategory.NORMAL), isNull())).thenReturn(mockNewList);
+        when(shoppingListService.createList(eq("My Party List"), eq("user@test.com"), eq(ListCategory.NORMAL), isNull()))
+                .thenReturn(mockNewList);
 
         // Act
-        aiPersistenceService.createListAndPopulateItems(null, "My New List", List.of(item), "user@test.com");
+        aiPersistenceService.createListAndPopulateItems(null, "My Party List", List.of(item), "user@test.com");
 
         // Assert
-        verify(shoppingListService, times(1)).createList(eq("My New List"), eq("user@test.com"), eq(ListCategory.NORMAL), isNull());
+        verify(shoppingListService, times(1)).createList(eq("My Party List"), eq("user@test.com"), eq(ListCategory.NORMAL), isNull());
         verify(itemService, times(1)).addItemsToList(eq(newListId), anyList(), eq("user@test.com"));
+    }
+
+    @Test
+    void createList_withNullIdAndBlankTitle_generatesDefaultTitleAndHandlesNullQuantity() {
+        // Arrange
+        ParsedItemResponse item = new ParsedItemResponse();
+        item.setGenericName("Water");
+
+        UUID newListId = UUID.randomUUID();
+        ShoppingListDTO mockNewList = new ShoppingListDTO();
+        mockNewList.setId(newListId);
+
+        String expectedDefaultTitle = "AI Generated " + LocalDate.now();
+        when(shoppingListService.createList(eq(expectedDefaultTitle), eq("user@test.com"), eq(ListCategory.NORMAL), isNull()))
+                .thenReturn(mockNewList);
+
+        // Act
+        aiPersistenceService.createListAndPopulateItems(null, "   ", List.of(item), "user@test.com");
+
+        // Assert
+        verify(shoppingListService, times(1)).createList(eq(expectedDefaultTitle), eq("user@test.com"), eq(ListCategory.NORMAL), isNull());
+
+        verify(itemService, times(1)).addItemsToList(eq(newListId), itemRequestCaptor.capture(), eq("user@test.com"));
+        ItemRequest savedItem = itemRequestCaptor.getValue().getFirst();
+        assertThat(savedItem.getQuantity()).isEmpty(); // "".trim() -> ""
+    }
+
+    @Test
+    void createList_withEmptyItems_doesNotCallItemService() {
+        // Arrange
+        UUID listId = UUID.randomUUID();
+
+        // Act
+        aiPersistenceService.createListAndPopulateItems(listId, "Title", Collections.emptyList(), "user@test.com");
+
+        // Assert
+        // Dacă primește o listă goală, nu ar trebui să apeleze baza de date pentru salvare itemi
+        verify(itemService, never()).addItemsToList(any(), any(), any());
     }
 }

--- a/src/test/java/com/p2ps/ai/service/GeminiServiceTest.java
+++ b/src/test/java/com/p2ps/ai/service/GeminiServiceTest.java
@@ -1,12 +1,20 @@
 package com.p2ps.ai.service;
 
+import com.p2ps.catalog.model.ProductCatalog;
+import com.p2ps.catalog.service.CatalogService;
 import com.p2ps.exception.AiProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.client.RestTemplate;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,14 +24,30 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GeminiServiceTest {
+
+    @Mock
+    private CatalogService catalogService;
 
     private GeminiService geminiService;
     private RestTemplate restTemplate;
 
+    private static final byte[] VALID_PNG = new byte[]{
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, (byte) 0xC4,
+            (byte) 0x89, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41,
+            0x54, 0x08, (byte) 0x99, 0x63, 0x60, 0x00, 0x02, 0x00,
+            0x00, 0x05, 0x00, 0x01, 0x22, 0x26, 0x05, (byte) 0xC3,
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+            (byte) 0xAE, 0x42, 0x60, (byte) 0x82
+    };
+
     @BeforeEach
     void setup() throws Exception {
-        geminiService = new GeminiService();
+        geminiService = new GeminiService(catalogService);
         restTemplate = mock(RestTemplate.class);
 
         Field restField = GeminiService.class.getDeclaredField("restTemplate");
@@ -32,35 +56,120 @@ class GeminiServiceTest {
 
         Field apiUrlField = GeminiService.class.getDeclaredField("apiUrl");
         apiUrlField.setAccessible(true);
-        apiUrlField.set(geminiService, "http://fake");
+        apiUrlField.set(geminiService, "http://fake-api-url");
 
         Field apiKeyField = GeminiService.class.getDeclaredField("apiKey");
         apiKeyField.setAccessible(true);
-        apiKeyField.set(geminiService, "key");
+        apiKeyField.set(geminiService, "fake-api-key");
     }
 
     @Test
     void whenRestThrows_shouldWrapInAiProcessingException() {
-        when(restTemplate.postForEntity(anyString(), any(), eq(String.class))).thenThrow(new RuntimeException("conn"));
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenThrow(new RuntimeException("Connection timeout"));
+
         assertThatThrownBy(() -> geminiService.extractIngredientsAsJson("text"))
-            .isInstanceOf(AiProcessingException.class)
-            .hasMessageContaining("Could not communicate with Google Gemini API");
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("Error during Multimodal AI processing");
     }
 
     @Test
     void whenNoCandidates_shouldThrow() {
-        when(restTemplate.postForEntity(anyString(), any(), eq(String.class))).thenReturn(ResponseEntity.ok("{\"candidates\":[]}"));
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("{\"candidates\":[]}"));
+
         assertThatThrownBy(() -> geminiService.extractIngredientsAsJson("text"))
-            .isInstanceOf(AiProcessingException.class)
-            .hasMessageContaining("Google API returned an empty response or blocked the request.");
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("Google API returned an empty response.");
     }
 
     @Test
-    void success_returnsText() {
-        String inner = "[{\"name\":\"Tomato\",\"quantity\":2,\"unit\":\"pieces\"}]";
-        String resp = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + inner.replace("\"","\\\"") + "\"}]}}]}";
-        when(restTemplate.postForEntity(anyString(), any(), eq(String.class))).thenReturn(ResponseEntity.ok(resp));
-        String result = geminiService.extractIngredientsAsJson("text");
-        assertThat(result).isEqualTo(inner);
+    void whenNoParts_shouldThrow() {
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+        String googleResponse = "{\"candidates\":[{\"content\":{}}]}";
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(googleResponse));
+
+        assertThatThrownBy(() -> geminiService.extractIngredientsAsJson("text"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("Google API returned candidate without text parts.");
+    }
+
+    @Test
+    void success_withTextOnly_returnsParsedJson() {
+        ProductCatalog mockProduct = new ProductCatalog();
+        mockProduct.setId(UUID.randomUUID());
+        mockProduct.setGenericName("Lapte");
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of(mockProduct));
+
+        String innerJson = "{\"listType\":\"RECIPE\",\"items\":[{\"genericName\":\"Lapte\",\"catalogId\":\"" + mockProduct.getId() + "\"}]}";
+        String googleResponse = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + innerJson.replace("\"", "\\\"") + "\"}]}}]}";
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(googleResponse));
+
+        String result = geminiService.extractIngredientsAsJson("Vreau o rețetă cu lapte.");
+
+        assertThat(result).isEqualTo(innerJson);
+    }
+
+    @Test
+    void success_withImageAndTextMultimodal_returnsParsedJson() {
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+
+        String innerJson = "{\"listType\":\"NORMAL\",\"items\":[]}";
+        String googleResponse = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + innerJson.replace("\"", "\\\"") + "\"}]}}]}";
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(googleResponse));
+
+        MockMultipartFile mockImage = new MockMultipartFile("image", "fridge.png", "image/png", VALID_PNG);
+
+        String result = geminiService.extractFromMultimodal(mockImage, "Ce am în frigider?");
+
+        assertThat(result).isEqualTo(innerJson);
+    }
+
+    @Test
+    void extractFromMultimodal_withInvalidImageSpoofing_throwsException() {
+        MockMultipartFile fakeImage = new MockMultipartFile("image", "virus.png", "image/png", "fake-pixel-data".getBytes());
+
+        assertThatThrownBy(() -> geminiService.extractFromMultimodal(fakeImage, "Ce am în poză?"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("Unsupported or corrupted image format");
+    }
+
+    @Test
+    void whenTextIsEmpty_shouldThrow() {
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+
+        String googleResponse = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"   \"}]}}]}";
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(googleResponse));
+
+        assertThatThrownBy(() -> geminiService.extractIngredientsAsJson("text"))
+                .isInstanceOf(AiProcessingException.class)
+                .hasMessageContaining("Google API returned an empty text response.");
+    }
+
+    @Test
+    void success_withImageAndNullText_usesFallbackPromptAndReturnsJson() {
+        when(catalogService.getTopPopularProducts()).thenReturn(List.of());
+
+        String innerJson = "{\"listType\":\"RECIPE\",\"items\":[]}";
+        String googleResponse = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"" + innerJson.replace("\"", "\\\"") + "\"}]}}]}";
+
+        when(restTemplate.postForEntity(anyString(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(googleResponse));
+
+        MockMultipartFile mockImage = new MockMultipartFile("image", "fridge.png", "image/png", VALID_PNG);
+
+        String result = geminiService.extractFromMultimodal(mockImage, null);
+
+        assertThat(result).isEqualTo(innerJson);
     }
 }

--- a/src/test/java/com/p2ps/catalog/service/CatalogServiceTest.java
+++ b/src/test/java/com/p2ps/catalog/service/CatalogServiceTest.java
@@ -51,12 +51,12 @@ class CatalogServiceTest {
 
         // Verify upsert was called correctly
         verify(catalogRepository).upsertProduct(genericName, specificName, brand, category, price);
-        
+
         // Verify the service returns the product found after upsert
         assertNotNull(result);
         assertEquals(specificName, result.getSpecificName());
     }
-    
+
     @Test
     void recordPurchaseShouldHandleNullGenericName() {
         String specificName = "Product without generic name";
@@ -75,9 +75,9 @@ class CatalogServiceTest {
         p1.setSpecificName("P1");
         ProductCatalog p2 = new ProductCatalog();
         p2.setSpecificName("P2");
-        
+
         List<ProductCatalog> expectedList = List.of(p1, p2);
-        
+
         when(catalogRepository.findTop50ByOrderByPurchaseCountDesc()).thenReturn(expectedList);
 
         List<ProductCatalog> result = catalogService.getTopPopularProducts();
@@ -92,9 +92,9 @@ class CatalogServiceTest {
         UUID catalogId = UUID.randomUUID();
         UUID store1 = UUID.randomUUID();
         UUID store2 = UUID.randomUUID();
-        
+
         List<UUID> expectedStores = List.of(store1, store2);
-        
+
         when(catalogRepository.findBestStoresForCatalogProduct(catalogId)).thenReturn(expectedStores);
 
         List<UUID> result = catalogService.getBestStoresForCatalogProduct(catalogId);
@@ -102,5 +102,47 @@ class CatalogServiceTest {
         assertEquals(2, result.size());
         assertEquals(expectedStores, result);
         verify(catalogRepository).findBestStoresForCatalogProduct(catalogId);
+    }
+    @Test
+    void recordPurchaseShouldThrowExceptionWhenProductNotFoundAfterUpsert() {
+        String specificName = "Ghost Product";
+        String brand = "Ghost Brand";
+
+        when(catalogRepository.findBySpecificNameAndBrand(specificName, brand)).thenReturn(Optional.empty());
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            catalogService.recordPurchase("Generic", specificName, brand, "Category", BigDecimal.TEN);
+        });
+
+        assertTrue(exception.getMessage().contains("Product should have been created by upsert"));
+    }
+
+    @Test
+    void searchProductsByNameShouldReturnEmptyListWhenKeywordIsNull() {
+        List<ProductCatalog> result = catalogService.searchProductsByName(null);
+
+        assertTrue(result.isEmpty());
+        verify(catalogRepository, never()).findByGenericNameContainingIgnoreCase(any());
+    }
+
+    @Test
+    void searchProductsByNameShouldReturnEmptyListWhenKeywordIsBlank() {
+        List<ProductCatalog> result = catalogService.searchProductsByName("   ");
+
+        assertTrue(result.isEmpty());
+        verify(catalogRepository, never()).findByGenericNameContainingIgnoreCase(any());
+    }
+
+    @Test
+    void searchProductsByNameShouldReturnMatchesWhenKeywordIsValid() {
+        ProductCatalog p1 = new ProductCatalog();
+        p1.setGenericName("Lapte");
+
+        when(catalogRepository.findByGenericNameContainingIgnoreCase("lapte")).thenReturn(List.of(p1));
+
+        List<ProductCatalog> result = catalogService.searchProductsByName("  lapte  ");
+
+        assertEquals(1, result.size());
+        verify(catalogRepository).findByGenericNameContainingIgnoreCase("lapte");
     }
 }

--- a/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
+++ b/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
@@ -54,6 +54,7 @@ class ShoppingListServiceTest {
     void createListShouldPersistListForExistingUser() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         ShoppingList savedList = new ShoppingList();
         UUID listId = UUID.randomUUID();
         savedList.setId(listId);
@@ -87,6 +88,7 @@ class ShoppingListServiceTest {
     void updateListShouldUpdateFieldsAndSave() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         UUID listId = UUID.randomUUID();
 
         ShoppingList existingList = new ShoppingList();
@@ -116,6 +118,7 @@ class ShoppingListServiceTest {
     void updateListShouldResetOptionalFieldsWhenEmptyString() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         UUID listId = UUID.randomUUID();
 
         ShoppingList existingList = new ShoppingList();
@@ -181,6 +184,7 @@ class ShoppingListServiceTest {
     void deleteListShouldRemoveOwnedList() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         UUID listId = UUID.randomUUID();
         ShoppingList list = new ShoppingList();
         list.setId(listId);
@@ -211,6 +215,7 @@ class ShoppingListServiceTest {
     void deleteListShouldThrowWhenUserDoesNotOwnList() {
         UUID listId = UUID.randomUUID();
         Users owner = new Users("owner@example.com", "secret", "Owner", "User");
+        owner.setId(1);
         ShoppingList list = new ShoppingList();
         list.setId(listId);
         list.setUser(owner);
@@ -230,6 +235,7 @@ class ShoppingListServiceTest {
     void getListByIdShouldReturnMappedDTO() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         UUID listId = UUID.randomUUID();
         ShoppingList list = new ShoppingList();
         list.setId(listId);
@@ -257,6 +263,7 @@ class ShoppingListServiceTest {
     void getListByIdShouldThrowWhenAccessDenied() {
         UUID listId = UUID.randomUUID();
         Users owner = new Users("owner@example.com", "secret", "Owner", "User");
+        owner.setId(1);
         ShoppingList list = new ShoppingList();
         list.setId(listId);
         list.setUser(owner);
@@ -271,6 +278,7 @@ class ShoppingListServiceTest {
     void importItemsShouldCopyAllItemsWhenNoItemIdsProvided() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
 
         UUID currentListId = UUID.randomUUID();
         ShoppingList currentList = new ShoppingList();
@@ -311,6 +319,7 @@ class ShoppingListServiceTest {
     void importItemsShouldCopyOnlySpecificItemsWhenItemIdsProvided() {
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
 
         UUID currentListId = UUID.randomUUID();
         ShoppingList currentList = new ShoppingList();
@@ -385,6 +394,7 @@ class ShoppingListServiceTest {
 
         String userEmail = "ana@example.com";
         Users user = new Users(userEmail, "secret", "Ana", "Ionescu");
+        user.setId(1);
         list.setUser(user);
         when(shoppingListRepository.findById(list.getId())).thenReturn(Optional.of(list));
 
@@ -401,7 +411,9 @@ class ShoppingListServiceTest {
         UUID listId = UUID.randomUUID();
         
         Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
         Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
         
         ShoppingList list = new ShoppingList();
         list.setId(listId);
@@ -423,6 +435,7 @@ class ShoppingListServiceTest {
         UUID listId = UUID.randomUUID();
         
         Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
         ShoppingList list = new ShoppingList();
         list.setId(listId);
         list.setUser(owner);
@@ -439,6 +452,7 @@ class ShoppingListServiceTest {
         UUID listId = UUID.randomUUID();
         
         Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
         ShoppingList list = new ShoppingList();
         list.setId(listId);
         list.setUser(owner);
@@ -456,6 +470,7 @@ class ShoppingListServiceTest {
         UUID listId = UUID.randomUUID();
         
         Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
         ShoppingList list = new ShoppingList();
         list.setId(listId);
         list.setUser(owner);
@@ -471,7 +486,9 @@ class ShoppingListServiceTest {
     void getListByIdShouldAllowCollaboratorAccess() {
         String collabEmail = "collab@example.com";
         Users owner = new Users("owner@example.com", "pass", "Owner", "User");
+        owner.setId(1);
         Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
         
         UUID listId = UUID.randomUUID();
         ShoppingList list = new ShoppingList();

--- a/src/test/java/com/p2ps/telemetry/services/TelemetryCleanupJobTest.java
+++ b/src/test/java/com/p2ps/telemetry/services/TelemetryCleanupJobTest.java
@@ -1,0 +1,50 @@
+package com.p2ps.telemetry.services;
+
+import com.p2ps.telemetry.repository.TelemetryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryCleanupJobTest {
+
+    @Mock
+    private TelemetryRepository telemetryRepository;
+
+    private TelemetryCleanupJob cleanupJob;
+
+    @BeforeEach
+    void setUp() {
+        cleanupJob = new TelemetryCleanupJob(telemetryRepository);
+        ReflectionTestUtils.setField(cleanupJob, "retentionDays", 7);
+    }
+
+    @Test
+    void shouldDeleteRecordsOlderThanRetentionPeriod() {
+        cleanupJob.deleteStaleRecords();
+
+        verify(telemetryRepository).deleteByTimestampBefore(anyLong());
+    }
+
+    @Test
+    void shouldUseCutoffOlderThan7Days() {
+        long before = System.currentTimeMillis();
+        cleanupJob.deleteStaleRecords();
+        long after = System.currentTimeMillis();
+
+        org.mockito.ArgumentCaptor<Long> captor = org.mockito.ArgumentCaptor.forClass(Long.class);
+        verify(telemetryRepository).deleteByTimestampBefore(captor.capture());
+
+        long cutoff = captor.getValue();
+        long sevenDaysMs = 7L * 24 * 60 * 60 * 1000;
+
+        assert cutoff <= before - sevenDaysMs;
+        assert cutoff >= after - sevenDaysMs - 1000;
+    }
+}

--- a/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
+++ b/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
@@ -179,6 +179,55 @@ class TelemetryServiceTest {
         verify(telemetryRepository).insert(org.mockito.ArgumentMatchers.anyList());
     }
 
+    @Test
+    void shouldDropDuplicatePingWithinDedupWindow() {
+        TelemetryPingDTO dto = buildPingDto();
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        TelemetryRecord recentRecord = new TelemetryRecord();
+        ReflectionTestUtils.setField(recentRecord, "timestamp", 1711888658000L); // același timestamp
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.of(recentRecord));
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldAllowPingAfterDedupWindowExpired() {
+        TelemetryPingDTO dto = buildPingDto(); // timestamp = 1711888658000L
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        TelemetryRecord oldRecord = new TelemetryRecord();
+        // timestamp mai vechi de 60 secunde față de ping
+        ReflectionTestUtils.setField(oldRecord, "timestamp", 1711888658000L - 120_000L);
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.of(oldRecord));
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldAllowPingWhenNoRecentRecordExists() {
+        TelemetryPingDTO dto = buildPingDto();
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.empty());
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
 
 
 }

--- a/src/test/java/com/p2ps/util/ImageValidationUtilTest.java
+++ b/src/test/java/com/p2ps/util/ImageValidationUtilTest.java
@@ -1,0 +1,85 @@
+package com.p2ps.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ImageValidationUtilTest {
+
+    private final ImageValidationUtil util = new ImageValidationUtil();
+
+    private static final byte[] VALID_PNG = new byte[]{
+            (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, (byte) 0xC4,
+            (byte) 0x89, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41,
+            0x54, 0x08, (byte) 0x99, 0x63, 0x60, 0x00, 0x02, 0x00,
+            0x00, 0x05, 0x00, 0x01, 0x22, 0x26, 0x05, (byte) 0xC3,
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+            (byte) 0xAE, 0x42, 0x60, (byte) 0x82
+    };
+
+    private static final byte[] VALID_JPEG = new byte[]{
+            (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+            0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+            0x01, 0x01, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00,
+            (byte) 0xFF, (byte) 0xDB, 0x00, 0x43, 0x00, 0x01,
+            (byte) 0xFF, (byte) 0xD9
+    };
+
+    @Test
+    void detectImageFormat_withValidPng_returnsPng() {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", VALID_PNG);
+
+        // Act
+        String format = util.detectImageFormat(file);
+
+        // Assert
+        assertThat(format).isEqualToIgnoringCase("png");
+    }
+
+    @Test
+    void detectImageFormat_withValidJpeg_returnsJpeg() {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", VALID_JPEG);
+
+        // Act
+        String format = util.detectImageFormat(file);
+
+        // Assert
+        assertThat(format).isEqualToIgnoringCase("jpeg");
+    }
+
+    @Test
+    void detectImageFormat_withInvalidFile_returnsNull() {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "Acesta este un text, nu o poza".getBytes());
+
+        // Act
+        String format = util.detectImageFormat(file);
+
+        // Assert
+        assertThat(format).isNull();
+    }
+
+    @Test
+    void detectImageFormat_whenIOExceptionOccurs_returnsNull() throws IOException {
+        // Arrange
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getInputStream()).thenThrow(new IOException("Stream error / Disk error"));
+
+        // Act
+        String format = util.detectImageFormat(mockFile);
+
+        // Assert
+        assertThat(format).isNull();
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -26,3 +26,10 @@ data-decay.enabled=true
 data-decay.penalty=0.02
 data-decay.cutoff-days=14
 data-decay.min-confidence-floor=0.15
+
+# Telemetry data retention
+telemetry.cleanup.cron=0 0 0 * * *
+telemetry.cleanup.retention-days=7
+
+# Telemetry deduplication
+telemetry.dedup.window-seconds=60


### PR DESCRIPTION
## Summary
Implements a data retention policy for telemetry records in MongoDB.

## Changes
- Added `TelemetryCleanupJob` — scheduled job that runs daily at midnight and deletes pings older than 7 days
- Added deduplication logic in `processPing()` — duplicate pings from the same device for the same item/store within a configurable time window (default 60s) are silently dropped
- Added `deleteByTimestampBefore()` to `TelemetryRepository` using `@Query(delete = true)`
- Added `@EnableScheduling` to `P2PShoppingApplication`
- Externalized config in `application.properties`:
  - `telemetry.cleanup.cron=0 0 0 * * *`
  - `telemetry.cleanup.retention-days=7`
  - `telemetry.dedup.window-seconds=60`
- Unit tests added for cleanup job and dedup logic

## Testing
- Manually tested deduplication via Postman — duplicate ping correctly dropped with log `[SERVICE] Duplicate ping dropped`
- Cleanup job tested locally with `retention-days=0` and cron every 30s

Closes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI list generation now accepts images alongside text for multimodal processing
  * Shopping lists now display owner name and email
  * Shopping items include enhanced product details (brand, generic/specific names, catalog ID, category)
  * Product catalog search by name

* **Chores**
  * Enabled Spring scheduling capabilities
  * Implemented automatic telemetry data cleanup and deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->