### PR TITLE
206 - telemetry data retention

### DIFF
--- a/src/main/java/com/p2ps/P2PShoppingApplication.java
+++ b/src/main/java/com/p2ps/P2PShoppingApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
 @EnableCaching
+@EnableScheduling
 public class P2PShoppingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/p2ps/telemetry/repository/TelemetryRepository.java
+++ b/src/main/java/com/p2ps/telemetry/repository/TelemetryRepository.java
@@ -2,6 +2,7 @@ package com.p2ps.telemetry.repository;
 
 import com.p2ps.telemetry.model.TelemetryRecord;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +14,7 @@ public interface TelemetryRepository extends MongoRepository<TelemetryRecord, St
     List<TelemetryRecord> findByStoreIdAndItemId(String storeId, String itemId);
 
     Optional<TelemetryRecord> findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(String deviceId, String storeId, String itemId);
+
+    @Query(value = "{ 'timestamp': { $lt: ?0 } }", delete = true)
+    void deleteByTimestampBefore(long timestamp);
 }

--- a/src/main/java/com/p2ps/telemetry/services/TelemetryCleanupJob.java
+++ b/src/main/java/com/p2ps/telemetry/services/TelemetryCleanupJob.java
@@ -1,0 +1,33 @@
+package com.p2ps.telemetry.services;
+
+import com.p2ps.telemetry.repository.TelemetryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TelemetryCleanupJob {
+
+    private final TelemetryRepository telemetryRepository;
+
+    @Value("${telemetry.cleanup.retention-days:7}")
+    private int retentionDays;
+
+    @Scheduled(cron = "${telemetry.cleanup.cron:0 0 0 * * *}")
+    public void deleteStaleRecords() {
+        long cutoff = Instant.now()
+                .minus(retentionDays, ChronoUnit.DAYS)
+                .toEpochMilli();
+
+        log.info("[CLEANUP] Deleting telemetry records older than {} days", retentionDays);
+        telemetryRepository.deleteByTimestampBefore(cutoff);
+        log.info("[CLEANUP] Done.");
+    }
+}

--- a/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
+++ b/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
@@ -29,15 +29,17 @@ public class TelemetryService {
     public void processPing(TelemetryPingDTO pingDTO) {
         log.info("[SERVICE] Processing ping for the product: {}", pingDTO.getItemId());
 
-        long windowStart = pingDTO.getTimestamp() - (dedupWindowSeconds * 1000);
-        Optional<TelemetryRecord> recent = telemetryRepository
-                .findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
-                        pingDTO.getDeviceId(), pingDTO.getStoreId(), pingDTO.getItemId());
+        if (pingDTO.getTimestamp() != null) {
+            long windowStart = pingDTO.getTimestamp() - (dedupWindowSeconds * 1000);
+            Optional<TelemetryRecord> recent = telemetryRepository
+                    .findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                            pingDTO.getDeviceId(), pingDTO.getStoreId(), pingDTO.getItemId());
 
-        if (recent.isPresent() && recent.get().getTimestamp() > windowStart) {
-            log.info("[SERVICE] Duplicate ping dropped for device: {}, item: {}",
-                    pingDTO.getDeviceId(), pingDTO.getItemId());
-            return;
+            if (recent.isPresent() && recent.get().getTimestamp() > windowStart) {
+                log.info("[SERVICE] Duplicate ping dropped for device: {}, item: {}",
+                        pingDTO.getDeviceId(), pingDTO.getItemId());
+                return;
+            }
         }
 
         TelemetryRecord telemetryRecord = mapToEntity(pingDTO);

--- a/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
+++ b/src/main/java/com/p2ps/telemetry/services/TelemetryService.java
@@ -2,9 +2,11 @@ package com.p2ps.telemetry.services;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import com.p2ps.telemetry.dto.TelemetryPingDTO;
@@ -20,16 +22,31 @@ public class TelemetryService {
     private final TelemetryRepository telemetryRepository;
     private final AnomalyDetectionService anomalyDetectionService;
 
+    @Value("${telemetry.dedup.window-seconds:60}")
+    private long dedupWindowSeconds;
+
     @Async("telemetryExecutor")
     public void processPing(TelemetryPingDTO pingDTO) {
         log.info("[SERVICE] Processing ping for the product: {}", pingDTO.getItemId());
+
+        long windowStart = pingDTO.getTimestamp() - (dedupWindowSeconds * 1000);
+        Optional<TelemetryRecord> recent = telemetryRepository
+                .findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                        pingDTO.getDeviceId(), pingDTO.getStoreId(), pingDTO.getItemId());
+
+        if (recent.isPresent() && recent.get().getTimestamp() > windowStart) {
+            log.info("[SERVICE] Duplicate ping dropped for device: {}, item: {}",
+                    pingDTO.getDeviceId(), pingDTO.getItemId());
+            return;
+        }
 
         TelemetryRecord telemetryRecord = mapToEntity(pingDTO);
         anomalyDetectionService.evaluateAndSetStatus(telemetryRecord);
 
         try {
             telemetryRepository.save(telemetryRecord);
-            log.info("[SERVICE] Ping successfully saved for product: {} with status: {}", pingDTO.getItemId(), telemetryRecord.getStatus());
+            log.info("[SERVICE] Ping successfully saved for product: {} with status: {}",
+                    pingDTO.getItemId(), telemetryRecord.getStatus());
         } catch (Exception e) {
             log.error("[SERVICE] Failed to save ping: {}", e.getMessage(), e);
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,10 @@ spring.servlet.multipart.max-request-size=5MB
 # Public OSRM demo endpoint is for light/demo use only.
 # Plan for self-hosted OSRM or managed provider for production.
 osrm.base-url=${OSRM_BASE_URL:https://router.project-osrm.org}
+
+# Telemetry data retention
+telemetry.cleanup.cron=0 0 0 * * *
+telemetry.cleanup.retention-days=7
+
+# Telemetry deduplication
+telemetry.dedup.window-seconds=60

--- a/src/test/java/com/p2ps/telemetry/services/TelemetryCleanupJobTest.java
+++ b/src/test/java/com/p2ps/telemetry/services/TelemetryCleanupJobTest.java
@@ -1,0 +1,50 @@
+package com.p2ps.telemetry.services;
+
+import com.p2ps.telemetry.repository.TelemetryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryCleanupJobTest {
+
+    @Mock
+    private TelemetryRepository telemetryRepository;
+
+    private TelemetryCleanupJob cleanupJob;
+
+    @BeforeEach
+    void setUp() {
+        cleanupJob = new TelemetryCleanupJob(telemetryRepository);
+        ReflectionTestUtils.setField(cleanupJob, "retentionDays", 7);
+    }
+
+    @Test
+    void shouldDeleteRecordsOlderThanRetentionPeriod() {
+        cleanupJob.deleteStaleRecords();
+
+        verify(telemetryRepository).deleteByTimestampBefore(anyLong());
+    }
+
+    @Test
+    void shouldUseCutoffOlderThan7Days() {
+        long before = System.currentTimeMillis();
+        cleanupJob.deleteStaleRecords();
+        long after = System.currentTimeMillis();
+
+        org.mockito.ArgumentCaptor<Long> captor = org.mockito.ArgumentCaptor.forClass(Long.class);
+        verify(telemetryRepository).deleteByTimestampBefore(captor.capture());
+
+        long cutoff = captor.getValue();
+        long sevenDaysMs = 7L * 24 * 60 * 60 * 1000;
+
+        assert cutoff <= before - sevenDaysMs;
+        assert cutoff >= after - sevenDaysMs - 1000;
+    }
+}

--- a/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
+++ b/src/test/java/com/p2ps/telemetry/services/TelemetryServiceTest.java
@@ -179,6 +179,55 @@ class TelemetryServiceTest {
         verify(telemetryRepository).insert(org.mockito.ArgumentMatchers.anyList());
     }
 
+    @Test
+    void shouldDropDuplicatePingWithinDedupWindow() {
+        TelemetryPingDTO dto = buildPingDto();
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        TelemetryRecord recentRecord = new TelemetryRecord();
+        ReflectionTestUtils.setField(recentRecord, "timestamp", 1711888658000L); // același timestamp
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.of(recentRecord));
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldAllowPingAfterDedupWindowExpired() {
+        TelemetryPingDTO dto = buildPingDto(); // timestamp = 1711888658000L
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        TelemetryRecord oldRecord = new TelemetryRecord();
+        // timestamp mai vechi de 60 secunde față de ping
+        ReflectionTestUtils.setField(oldRecord, "timestamp", 1711888658000L - 120_000L);
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.of(oldRecord));
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldAllowPingWhenNoRecentRecordExists() {
+        TelemetryPingDTO dto = buildPingDto();
+        ReflectionTestUtils.setField(telemetryService, "dedupWindowSeconds", 60L);
+
+        when(telemetryRepository.findTopByDeviceIdAndStoreIdAndItemIdOrderByTimestampDesc(
+                "device-1", "store-7", "item-101"))
+                .thenReturn(java.util.Optional.empty());
+
+        telemetryService.processPing(dto);
+
+        verify(telemetryRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
 
 
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -26,3 +26,10 @@ data-decay.enabled=true
 data-decay.penalty=0.02
 data-decay.cutoff-days=14
 data-decay.min-confidence-floor=0.15
+
+# Telemetry data retention
+telemetry.cleanup.cron=0 0 0 * * *
+telemetry.cleanup.retention-days=7
+
+# Telemetry deduplication
+telemetry.dedup.window-seconds=60


### PR DESCRIPTION
## Summary
Implements a data retention policy for telemetry records in MongoDB.

## Changes
- Added `TelemetryCleanupJob` — scheduled job that runs daily at midnight and deletes pings older than 7 days
- Added deduplication logic in `processPing()` — duplicate pings from the same device for the same item/store within a configurable time window (default 60s) are silently dropped
- Added `deleteByTimestampBefore()` to `TelemetryRepository` using `@Query(delete = true)`
- Added `@EnableScheduling` to `P2PShoppingApplication`
- Externalized config in `application.properties`:
  - `telemetry.cleanup.cron=0 0 0 * * *`
  - `telemetry.cleanup.retention-days=7`
  - `telemetry.dedup.window-seconds=60`
- Unit tests added for cleanup job and dedup logic

## Testing
- Manually tested deduplication via Postman — duplicate ping correctly dropped with log `[SERVICE] Duplicate ping dropped`
- Cleanup job tested locally with `retention-days=0` and cron every 30s

Closes #206 