### PR TITLE
feature: add route statistics api implementation

### DIFF
--- a/src/main/java/com/p2ps/controller/RoutingResponse.java
+++ b/src/main/java/com/p2ps/controller/RoutingResponse.java
@@ -28,6 +28,13 @@ public class RoutingResponse implements Serializable {
     private String routeId;
     private boolean partial;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("total_distance_meters")
+    private double totalDistanceMeters;
+    @com.fasterxml.jackson.annotation.JsonProperty("estimated_time_seconds")
+    private int estimatedTimeSeconds;
+    @com.fasterxml.jackson.annotation.JsonProperty("total_stops")
+    private int totalStops;
+
     /**
      * 3-arg constructor kept for backward compatibility with existing tests
      * (RoutingResponseTest, RoutingControllerTest).
@@ -39,6 +46,9 @@ public class RoutingResponse implements Serializable {
         this.warnings = warnings;
         this.routeId = null;
         this.partial = false;
+        this.totalDistanceMeters = 0.0;
+        this.estimatedTimeSeconds = 0;
+        this.totalStops = 0;
     }
 
     // ------------------------------------------------------------------
@@ -47,21 +57,21 @@ public class RoutingResponse implements Serializable {
 
     /** Full eager response: 3-opt done, no routeId needed. */
     public static RoutingResponse eager(List<RoutePoint> route, List<String> warnings) {
-        return new RoutingResponse("success", route, warnings, null, false);
+        return new RoutingResponse("success", route, warnings, null, false, 0.0, 0, 0);
     }
 
     /** Partial lazy response: first N stops, full route computing in background. */
     public static RoutingResponse partial(String routeId, List<RoutePoint> partialRoute, List<String> warnings) {
-        return new RoutingResponse("partial", partialRoute, warnings, routeId, true);
+        return new RoutingResponse("partial", partialRoute, warnings, routeId, true, 0.0, 0, 0);
     }
 
     /** Full response retrieved from Redis after background optimization. */
     public static RoutingResponse full(String routeId, List<RoutePoint> route, List<String> warnings) {
-        return new RoutingResponse("success", route, warnings, routeId, false);
+        return new RoutingResponse("success", route, warnings, routeId, false, 0.0, 0, 0);
     }
 
     /** Error response. */
     public static RoutingResponse error(String message) {
-        return new RoutingResponse("error", List.of(), List.of(message), null, false);
+        return new RoutingResponse("error", List.of(), List.of(message), null, false, 0.0, 0, 0);
     }
 }

--- a/src/main/java/com/p2ps/service/RoutingAsyncService.java
+++ b/src/main/java/com/p2ps/service/RoutingAsyncService.java
@@ -60,6 +60,10 @@ public class RoutingAsyncService {
             List<RoutePoint> optimized = optimizer.threeOptImprove(fullNnRoute);
 
             RoutingResponse fullResponse = RoutingResponse.full(routeId, optimized, warnings);
+            fullResponse.setTotalDistanceMeters(optimizer.routeDistance(optimized));
+            fullResponse.setTotalStops(optimized.size() - 1);
+            fullResponse.setEstimatedTimeSeconds((int) (fullResponse.getTotalDistanceMeters() / 1.4));
+
             String json = objectMapper.writeValueAsString(fullResponse);
 
             redis.opsForValue().set(ROUTE_KEY_PREFIX + routeId, json, ROUTE_TTL);

--- a/src/main/java/com/p2ps/service/RoutingService.java
+++ b/src/main/java/com/p2ps/service/RoutingService.java
@@ -79,7 +79,14 @@ public class RoutingService {
         List<RoutePoint> optimizedRoute = optimizer.threeOptImprove(nnRoute);
         logImprovement(nnRoute, optimizedRoute);
         logger.info("Ruta calculata: {} puncte, {} warnings", optimizedRoute.size(), warnings.size());
-        return RoutingResponse.eager(optimizedRoute, warnings);
+
+        RoutingResponse response = RoutingResponse.eager(optimizedRoute, warnings);
+        response.setTotalDistanceMeters(optimizer.routeDistance(optimizedRoute));
+        response.setTotalStops(optimizedRoute.size() - 1);
+        // Assuming walking speed of ~1.4 m/s
+        response.setEstimatedTimeSeconds((int) (response.getTotalDistanceMeters() / 1.4));
+
+        return response;
     }
 
     /**
@@ -107,7 +114,12 @@ public class RoutingService {
         // Fire-and-forget: 3-opt on full route → Redis
         asyncService.completeRouteAsync(routeId, new ArrayList<>(fullNnRoute), new ArrayList<>(warnings));
 
-        return RoutingResponse.partial(routeId, new ArrayList<>(partial), warnings);
+        RoutingResponse response = RoutingResponse.partial(routeId, new ArrayList<>(partial), warnings);
+        response.setTotalDistanceMeters(optimizer.routeDistance(partial));
+        response.setTotalStops(partial.size() - 1);
+        response.setEstimatedTimeSeconds((int) (response.getTotalDistanceMeters() / 1.4));
+
+        return response;
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/p2ps/controller/RoutingResponseTest.java
+++ b/src/test/java/com/p2ps/controller/RoutingResponseTest.java
@@ -28,4 +28,16 @@ class RoutingResponseTest {
         assertEquals("updated", response.getStatus());
         assertEquals(updatedRoute, response.getRoute());
     }
+
+    @Test
+    void shouldExposeNewMetricsFields() {
+        RoutingResponse response = new RoutingResponse();
+        response.setTotalDistanceMeters(140.5);
+        response.setEstimatedTimeSeconds(100);
+        response.setTotalStops(5);
+
+        assertEquals(140.5, response.getTotalDistanceMeters());
+        assertEquals(100, response.getEstimatedTimeSeconds());
+        assertEquals(5, response.getTotalStops());
+    }
 }

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -250,4 +250,26 @@ class RoutingServiceTest {
         assertFalse(response.getWarnings().isEmpty());
         assertTrue(response.getWarnings().stream().anyMatch(w -> w.contains("incredere scazut")));
     }
+
+    @Test
+    void calculateOptimalRoute_shouldExposeRouteMetrics() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871, 0.9);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(p1));
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        assertNotNull(response.getTotalDistanceMeters());
+        assertNotNull(response.getEstimatedTimeSeconds());
+        assertNotNull(response.getTotalStops());
+
+        assertTrue(response.getTotalDistanceMeters() > 0);
+        assertTrue(response.getEstimatedTimeSeconds() > 0);
+        assertTrue(response.getTotalStops() > 0);
+    }
 }

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -264,10 +264,7 @@ class RoutingServiceTest {
         RoutingResponse response = service.calculateOptimalRoute(request);
 
         assertEquals("success", response.getStatus());
-        assertNotNull(response.getTotalDistanceMeters());
-        assertNotNull(response.getEstimatedTimeSeconds());
-        assertNotNull(response.getTotalStops());
-
+        // primitives can't be null; assert they have sensible positive values
         assertTrue(response.getTotalDistanceMeters() > 0);
         assertTrue(response.getEstimatedTimeSeconds() > 0);
         assertTrue(response.getTotalStops() > 0);


### PR DESCRIPTION
Adds route-level metrics to routing responses and computes them in both eager and lazy flows.
### **Changes**
**Extended RoutingResponse with:**

- total_distance_meters

- estimated_time_seconds

- total_stops

**Computed metrics in RoutingService using routeDistance(...) and route size:**

- total_distance_meters = routeDistance(route)

- total_stops = route.size() - 1 (excluding user_loc)

- estimated_time_seconds = floor(total_distance_meters / 1.4)

**Applied the same metrics logic to async full-route completion in RoutingAsyncService (Redis-stored lazy result).**

**Added/updated tests in RoutingResponseTest and RoutingServiceTest for new fields and metric population.**

### **How to test**

 call POST /api/routing/calculate and verify response contains:

- total_distance_meters
- estimated_time_seconds
- total_stops

Closes P2P-Shopping/server#157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Routing responses now include calculated metrics: total distance, estimated delivery time, and number of stops for each route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->