### PR TITLE
feat(routing): closed-loop TSP with fixed checkout endpoint

### DIFF
--- a/init-scripts/04-add-store-entry-exit-points.sql
+++ b/init-scripts/04-add-store-entry-exit-points.sql
@@ -1,0 +1,11 @@
+-- Issue #154: Closed-Loop TSP — Fix Start / Finish
+-- Adds entry_point (user enters) and exit_point (checkout counters) to every store.
+-- Both columns are nullable so existing stores without coordinates still work.
+
+ALTER TABLE store_geofences
+    ADD COLUMN IF NOT EXISTS entry_point GEOMETRY(Point, 4326),
+    ADD COLUMN IF NOT EXISTS exit_point  GEOMETRY(Point, 4326);
+
+-- Spatial index on exit_point — used by RoutingService.fetchExitPoint()
+CREATE INDEX IF NOT EXISTS idx_store_geofences_exit_point
+    ON store_geofences USING GIST (exit_point);

--- a/init-scripts/99-populare.sql
+++ b/init-scripts/99-populare.sql
@@ -10,14 +10,28 @@ INSERT INTO users (first_name, last_name, email, password, token_version, create
 ON CONFLICT (email) DO NOTHING;
 
 
-INSERT INTO store_geofences (store_id, name, boundary_polygon, floor_level) VALUES
-('8f3e1a2b-c4d5-6e7f-8a9b-0c1d2e3f4a5b', 'Supermarket Palas', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.586,47.155],[27.588,47.155],[27.588,47.157],[27.586,47.157],[27.586,47.155]]]}'), 4326), 0),
- ('a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d', 'Iulius Mall', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.599,47.156],[27.601,47.156],[27.601,47.158],[27.599,47.158],[27.599,47.156]]]}'), 4326), 0),
- ('f1e2d3c4-b5a6-9f8e-7d6c-5b4a3f2e1d0c', 'Kaufland Tudor', ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.604,47.149],[27.606,47.149],[27.606,47.151],[27.604,47.151],[27.604,47.149]]]}'), 4326), 0)
+INSERT INTO store_geofences (store_id, name, boundary_polygon, floor_level, entry_point, exit_point) VALUES
+('8f3e1a2b-c4d5-6e7f-8a9b-0c1d2e3f4a5b', 'Supermarket Palas',
+    ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.586,47.155],[27.588,47.155],[27.588,47.157],[27.586,47.157],[27.586,47.155]]]}'), 4326),
+    0,
+    ST_SetSRID(ST_MakePoint(27.5870, 47.1551), 4326),  -- intrare (sud)
+    ST_SetSRID(ST_MakePoint(27.5875, 47.1565), 4326)), -- case de marcat (nord)
+('a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d', 'Iulius Mall',
+    ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.599,47.156],[27.601,47.156],[27.601,47.158],[27.599,47.158],[27.599,47.156]]]}'), 4326),
+    0,
+    ST_SetSRID(ST_MakePoint(27.5991, 47.1561), 4326),  -- intrare
+    ST_SetSRID(ST_MakePoint(27.6008, 47.1575), 4326)), -- case de marcat
+('f1e2d3c4-b5a6-9f8e-7d6c-5b4a3f2e1d0c', 'Kaufland Tudor',
+    ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[27.604,47.149],[27.606,47.149],[27.606,47.151],[27.604,47.151],[27.604,47.149]]]}'), 4326),
+    0,
+    ST_SetSRID(ST_MakePoint(27.6041, 47.1491), 4326),  -- intrare
+    ST_SetSRID(ST_MakePoint(27.6053, 47.1498), 4326))  -- case de marcat
     ON CONFLICT (store_id) DO UPDATE SET
-    boundary_polygon = EXCLUDED.boundary_polygon,
-                                  name = EXCLUDED.name,
-                                  floor_level = EXCLUDED.floor_level;
+        boundary_polygon = EXCLUDED.boundary_polygon,
+        name             = EXCLUDED.name,
+        floor_level      = EXCLUDED.floor_level,
+        entry_point      = EXCLUDED.entry_point,
+        exit_point       = EXCLUDED.exit_point;
 
 
 -- 2. Seed shopping lists doar pentru userii existenti in aplicatie

--- a/src/main/java/com/p2ps/controller/RoutePoint.java
+++ b/src/main/java/com/p2ps/controller/RoutePoint.java
@@ -1,6 +1,5 @@
 package com.p2ps.controller;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -8,12 +7,37 @@ import java.io.Serializable;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
-
 public class RoutePoint implements Serializable {
+
     private String itemId;
     private String name;
     private double lat;
     private double lng;
 
+    /**
+     * UI hint for the frontend so it can render each stop differently.
+     * <ul>
+     *   <li>{@code "USER"}     — the shopper's current position (first node)</li>
+     *   <li>{@code "PRODUCT"}  — a product stop (default for the 4-arg constructor)</li>
+     *   <li>{@code "CHECKOUT"} — the checkout / exit point (last node, issue #154)</li>
+     * </ul>
+     */
+    private String type;
+
+    /**
+     * Backward-compatible constructor — keeps all existing call-sites unchanged.
+     * Type defaults to "PRODUCT".
+     */
+    public RoutePoint(String itemId, String name, double lat, double lng) {
+        this(itemId, name, lat, lng, "PRODUCT");
+    }
+
+    /** Full constructor used when the type is known (USER / CHECKOUT). */
+    public RoutePoint(String itemId, String name, double lat, double lng, String type) {
+        this.itemId = itemId;
+        this.name   = name;
+        this.lat    = lat;
+        this.lng    = lng;
+        this.type   = type;
+    }
 }

--- a/src/main/java/com/p2ps/service/RoutingService.java
+++ b/src/main/java/com/p2ps/service/RoutingService.java
@@ -30,18 +30,14 @@ public class RoutingService {
     private final StringRedisTemplate redis;
 
     public RoutingService(JdbcTemplate jdbcTemplate,
-                          RouteOptimizer optimizer,
-                          RoutingAsyncService asyncService,
-                          StringRedisTemplate redis) {
+            RouteOptimizer optimizer,
+            RoutingAsyncService asyncService,
+            StringRedisTemplate redis) {
         this.jdbcTemplate = jdbcTemplate;
         this.optimizer = optimizer;
         this.asyncService = asyncService;
         this.redis = redis;
     }
-
-    // -------------------------------------------------------------------------
-    // BE 3.1 — Lazy Routing entry point
-    // -------------------------------------------------------------------------
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public RoutingResponse calculateOptimalRoute(RoutingRequest request) {
@@ -62,7 +58,6 @@ public class RoutingService {
             return RoutingResponse.error("Niciunul din produsele cerute nu a fost gasit in magazin.");
         }
 
-        // Issue #154 — Closed-Loop TSP:
         // Fetch the store's exit point (checkout counters).
         // If the store doesn't have one yet (column is NULL) we fall back
         // gracefully to the old open-path behaviour.
@@ -108,8 +103,6 @@ public class RoutingService {
     }
 
     /**
-     * BE 3.1 — Lazy path.
-     *
      * Returns the first lazyN stops immediately (NN order, no 3-opt yet).
      * Schedules full 3-opt optimization in the background.
      * The checkout point is always part of the full (background) route but is
@@ -117,8 +110,8 @@ public class RoutingService {
      * end when the frontend polls GET /api/routing/full/{routeId}.
      */
     private RoutingResponse handleLazyRoute(List<RoutePoint> fullNnRoute,
-                                             int lazyN,
-                                             List<String> warnings) {
+            int lazyN,
+            List<String> warnings) {
         String routeId = UUID.randomUUID().toString();
 
         // Partial response: user point + first lazyN products
@@ -154,19 +147,18 @@ public class RoutingService {
     }
 
     /**
-     * Issue #154 — fetches the checkout / exit point for a store.
-     *
      * Returns {@code null} when:
      * <ul>
-     *   <li>the store's {@code exit_point} column is NULL (not yet configured), or</li>
-     *   <li>the store_id doesn't exist (shouldn't happen, but safe).</li>
+     * <li>the store's {@code exit_point} column is NULL (not yet configured),
+     * or</li>
+     * <li>the store_id doesn't exist (shouldn't happen, but safe).</li>
      * </ul>
      * In both cases the caller falls back to the open-path behaviour.
      */
     private RoutePoint fetchExitPoint(String storeId) {
         String sql = "SELECT ST_Y(exit_point) AS lat, ST_X(exit_point) AS lng " +
-                     "FROM store_geofences " +
-                     "WHERE store_id::text = ? AND exit_point IS NOT NULL";
+                "FROM store_geofences " +
+                "WHERE store_id::text = ? AND exit_point IS NOT NULL";
         try {
             return jdbcTemplate.queryForObject(sql,
                     (rs, rowNum) -> new RoutePoint(
@@ -176,7 +168,7 @@ public class RoutingService {
                             rs.getDouble("lng"),
                             "CHECKOUT"),
                     storeId);
-        } catch (EmptyResultDataAccessException e) {
+        } catch (EmptyResultDataAccessException _) {
             logger.info("Magazinul {} nu are un exit_point configurat — ruta ramane deschisa.", storeId);
             return null;
         } catch (Exception e) {
@@ -186,7 +178,8 @@ public class RoutingService {
     }
 
     private List<ProductLocation> getProductLocations(List<String> productIds, String storeId, List<String> warnings) {
-        if (productIds == null || productIds.isEmpty()) return List.of();
+        if (productIds == null || productIds.isEmpty())
+            return List.of();
 
         List<ProductLocation> locations = queryInventoryMap(productIds, storeId, warnings);
 
@@ -220,17 +213,14 @@ public class RoutingService {
                         rs.getString("name"),
                         rs.getDouble("lat"),
                         rs.getDouble("lng"),
-                        rs.getDouble("confidence_score")
-                ),
-                params.toArray(new Object[0])
-        );
+                        rs.getDouble("confidence_score")),
+                params.toArray(new Object[0]));
 
         for (ProductLocation loc : results) {
             if (loc.confidenceScore() < CONFIDENCE_THRESHOLD) {
                 warnings.add(String.format(
                         "Locatia produsului '%s' are un grad de incredere scazut (%.0f%%).",
-                        loc.name(), loc.confidenceScore() * 100
-                ));
+                        loc.name(), loc.confidenceScore() * 100));
             }
         }
 
@@ -270,10 +260,8 @@ public class RoutingService {
                         rs.getString("name"),
                         rs.getDouble("lat"),
                         rs.getDouble("lng"),
-                        rs.getDouble("confidence_score")
-                ),
-                params.toArray(new Object[0])
-        );
+                        rs.getDouble("confidence_score")),
+                params.toArray(new Object[0]));
         logger.info(">>> Query terminat, {} rezultate", result.size());
         return result;
     }
@@ -283,13 +271,15 @@ public class RoutingService {
     // -------------------------------------------------------------------------
 
     private void logImprovement(List<RoutePoint> before, List<RoutePoint> after) {
-        if (!logger.isInfoEnabled()) return;
+        if (!logger.isInfoEnabled())
+            return;
         double distBefore = optimizer.routeDistance(before);
-        double distAfter  = optimizer.routeDistance(after);
+        double distAfter = optimizer.routeDistance(after);
         logger.info("NN: {}m | 3-Opt: {}m | Imbunatatire: {}%",
                 (int) distBefore, (int) distAfter,
                 String.format("%.1f", distBefore > 0
-                        ? (distBefore - distAfter) / distBefore * 100 : 0));
+                        ? (distBefore - distAfter) / distBefore * 100
+                        : 0));
     }
 
     private List<RoutePoint> toRoutePoints(List<ProductLocation> locations) {
@@ -298,5 +288,6 @@ public class RoutingService {
                 .toList();
     }
 
-    public record ProductLocation(String itemId, String name, double lat, double lng, double confidenceScore) {}
+    public record ProductLocation(String itemId, String name, double lat, double lng, double confidenceScore) {
+    }
 }

--- a/src/main/java/com/p2ps/service/RoutingService.java
+++ b/src/main/java/com/p2ps/service/RoutingService.java
@@ -5,6 +5,7 @@ import com.p2ps.controller.RoutingResponse;
 import com.p2ps.controller.RoutePoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -61,21 +62,38 @@ public class RoutingService {
             return RoutingResponse.error("Niciunul din produsele cerute nu a fost gasit in magazin.");
         }
 
-        RoutePoint userPoint = new RoutePoint("user_loc", "Tu", request.getUserLat(), request.getUserLng());
+        // Issue #154 — Closed-Loop TSP:
+        // Fetch the store's exit point (checkout counters).
+        // If the store doesn't have one yet (column is NULL) we fall back
+        // gracefully to the old open-path behaviour.
+        RoutePoint checkoutPoint = fetchExitPoint(storeId);
 
-        // Full NN route (fast — always computed eagerly)
+        RoutePoint userPoint = new RoutePoint("user_loc", "Tu",
+                request.getUserLat(), request.getUserLng(), "USER");
+
+        // NN route: user → products (nearest-neighbour order)
         List<RoutePoint> nnRoute = new ArrayList<>();
         nnRoute.add(userPoint);
         nnRoute.addAll(optimizer.nearestNeighborTSP(userPoint, toRoutePoints(locations)));
 
+        // Pin checkout as the fixed last node.
+        // RouteOptimizer.threeOptImprove() never moves index 0 (user) or the
+        // last index (checkout) — segA and segD are always preserved as-is.
+        if (checkoutPoint != null) {
+            nnRoute.add(checkoutPoint);
+            logger.info("Ruta inchisa: {} → {} produse → Casa de marcat", "user_loc", locations.size());
+        } else {
+            logger.info("Ruta deschisa (magazinul nu are exit_point configurat).");
+        }
+
         int lazyN = request.getLazyN();
-        boolean goLazy = lazyN > 0 && nnRoute.size() > lazyN + 1; // +1 for user point
+        boolean goLazy = lazyN > 0 && nnRoute.size() > lazyN + 1;
 
         if (goLazy) {
             return handleLazyRoute(nnRoute, lazyN, warnings);
         }
 
-        // Eager path — same as before
+        // Eager path — 3-opt on the full route (start and end pinned)
         List<RoutePoint> optimizedRoute = optimizer.threeOptImprove(nnRoute);
         logImprovement(nnRoute, optimizedRoute);
         logger.info("Ruta calculata: {} puncte, {} warnings", optimizedRoute.size(), warnings.size());
@@ -87,7 +105,9 @@ public class RoutingService {
      *
      * Returns the first lazyN stops immediately (NN order, no 3-opt yet).
      * Schedules full 3-opt optimization in the background.
-     * The frontend polls GET /api/routing/full/{routeId} when it needs the rest.
+     * The checkout point is always part of the full (background) route but is
+     * intentionally excluded from the partial response — it will appear at the
+     * end when the frontend polls GET /api/routing/full/{routeId}.
      */
     private RoutingResponse handleLazyRoute(List<RoutePoint> fullNnRoute,
                                              int lazyN,
@@ -95,7 +115,7 @@ public class RoutingService {
         String routeId = UUID.randomUUID().toString();
 
         // Partial response: user point + first lazyN products
-        List<RoutePoint> partial = fullNnRoute.subList(0, lazyN + 1); // inclusive of user point
+        List<RoutePoint> partial = fullNnRoute.subList(0, lazyN + 1);
 
         logger.info("Lazy routing: returnez {} noduri imediat, {} in background (routeId={})",
                 partial.size(), fullNnRoute.size() - partial.size(), routeId);
@@ -104,14 +124,14 @@ public class RoutingService {
         String pendingKey = RoutingAsyncService.PENDING_KEY_PREFIX + routeId;
         redis.opsForValue().set(pendingKey, "true", RoutingAsyncService.PENDING_TTL);
 
-        // Fire-and-forget: 3-opt on full route → Redis
+        // Fire-and-forget: 3-opt on full route (checkout pinned at end) → Redis
         asyncService.completeRouteAsync(routeId, new ArrayList<>(fullNnRoute), new ArrayList<>(warnings));
 
         return RoutingResponse.partial(routeId, new ArrayList<>(partial), warnings);
     }
 
     // -------------------------------------------------------------------------
-    // DB queries (unchanged from original)
+    // DB queries
     // -------------------------------------------------------------------------
 
     private String findStoreForUser(double lat, double lng) {
@@ -119,6 +139,38 @@ public class RoutingService {
                 "WHERE ST_Contains(boundary_polygon, ST_SetSRID(ST_MakePoint(?, ?), 4326)) LIMIT 1";
         List<String> results = jdbcTemplate.queryForList(sql, String.class, lng, lat);
         return results.isEmpty() ? null : results.get(0);
+    }
+
+    /**
+     * Issue #154 — fetches the checkout / exit point for a store.
+     *
+     * Returns {@code null} when:
+     * <ul>
+     *   <li>the store's {@code exit_point} column is NULL (not yet configured), or</li>
+     *   <li>the store_id doesn't exist (shouldn't happen, but safe).</li>
+     * </ul>
+     * In both cases the caller falls back to the open-path behaviour.
+     */
+    private RoutePoint fetchExitPoint(String storeId) {
+        String sql = "SELECT ST_Y(exit_point) AS lat, ST_X(exit_point) AS lng " +
+                     "FROM store_geofences " +
+                     "WHERE store_id::text = ? AND exit_point IS NOT NULL";
+        try {
+            return jdbcTemplate.queryForObject(sql,
+                    (rs, rowNum) -> new RoutePoint(
+                            "checkout",
+                            "Casa de marcat",
+                            rs.getDouble("lat"),
+                            rs.getDouble("lng"),
+                            "CHECKOUT"),
+                    storeId);
+        } catch (EmptyResultDataAccessException e) {
+            logger.info("Magazinul {} nu are un exit_point configurat — ruta ramane deschisa.", storeId);
+            return null;
+        } catch (Exception e) {
+            logger.warn("Nu am putut prelua exit_point pentru magazinul {}: {}", storeId, e.getMessage());
+            return null;
+        }
     }
 
     private List<ProductLocation> getProductLocations(List<String> productIds, String storeId, List<String> warnings) {

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -250,4 +250,78 @@ class RoutingServiceTest {
         assertFalse(response.getWarnings().isEmpty());
         assertTrue(response.getWarnings().stream().anyMatch(w -> w.contains("incredere scazut")));
     }
+
+    // -------------------------------------------------------------------------
+    // Issue #154 — Closed-Loop TSP (start = user, end = checkout)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void calculateOptimalRoute_shouldEndAtCheckoutWhenExitPointExists() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "P1", 47.1562, 27.5871, 0.9);
+        RoutingService.ProductLocation p2 = new RoutingService.ProductLocation(ITEM_2, "P2", 47.1558, 27.5865, 0.8);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(p1, p2));
+
+        RoutePoint checkout = new RoutePoint("checkout", "Casa de marcat", 47.1569, 27.5880, "CHECKOUT");
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), anyString()))
+                .thenReturn(checkout);
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1, ITEM_2), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        List<RoutePoint> route = response.getRoute();
+        assertFalse(route.isEmpty());
+
+        // First node must be the user position
+        assertEquals("user_loc", route.get(0).getItemId());
+        assertEquals("USER", route.get(0).getType());
+
+        // Last node must be the checkout counter -- closed loop
+        RoutePoint last = route.get(route.size() - 1);
+        assertEquals("checkout", last.getItemId());
+        assertEquals("CHECKOUT", last.getType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void calculateOptimalRoute_shouldWorkWithoutExitPoint() {
+        // Backward-compatibility: stores without exit_point still work.
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "P1", 47.1562, 27.5871, 0.9);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(p1));
+        // queryForObject not mocked -> returns null -> no checkout node appended
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        assertFalse(response.getRoute().isEmpty());
+
+        // Route must NOT end with a checkout node
+        RoutePoint last = response.getRoute().get(response.getRoute().size() - 1);
+        assertNotEquals("checkout", last.getItemId());
+    }
+
+    @Test
+    void routePoint_shouldDefaultTypeToProduct() {
+        RoutePoint p = new RoutePoint("id123", "Lapte", 47.156, 27.587);
+        assertEquals("PRODUCT", p.getType());
+    }
+
+    @Test
+    void routePoint_shouldSupportExplicitType() {
+        RoutePoint checkout = new RoutePoint("checkout", "Casa de marcat", 47.156, 27.587, "CHECKOUT");
+        assertEquals("CHECKOUT", checkout.getType());
+
+        RoutePoint user = new RoutePoint("user_loc", "Tu", 47.156, 27.587, "USER");
+        assertEquals("USER", user.getType());
+    }
 }

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -77,8 +77,7 @@ class RoutingServiceTest {
         List<RoutePoint> points = List.of(
                 new RoutePoint(ITEM_1, "A", 47.157, 27.588),
                 new RoutePoint(ITEM_2, "B", 47.158, 27.589),
-                new RoutePoint(ITEM_3, "C", 47.159, 27.590)
-        );
+                new RoutePoint(ITEM_3, "C", 47.159, 27.590));
 
         List<RoutePoint> route = optimizer.nearestNeighborTSP(start, points);
 
@@ -116,8 +115,7 @@ class RoutingServiceTest {
                 new RoutePoint("u", "Tu", 47.156, 27.587),
                 new RoutePoint(ITEM_1, "A", 47.160, 27.595),
                 new RoutePoint(ITEM_2, "B", 47.158, 27.591),
-                new RoutePoint(ITEM_3, "C", 47.162, 27.600)
-        );
+                new RoutePoint(ITEM_3, "C", 47.162, 27.600));
 
         double before = optimizer.routeDistance(route);
         List<RoutePoint> improved = optimizer.threeOptImprove(route);
@@ -126,7 +124,6 @@ class RoutingServiceTest {
         assertTrue(after <= before + 1e-9);
         assertEquals(route.size(), improved.size());
     }
-    
 
     @Test
     void threeOptImprove_shouldReturnAllSamePoints() {
@@ -134,8 +131,7 @@ class RoutingServiceTest {
                 new RoutePoint("u", "Tu", 47.156, 27.587),
                 new RoutePoint(ITEM_1, "A", 47.160, 27.595),
                 new RoutePoint(ITEM_2, "B", 47.155, 27.580),
-                new RoutePoint(ITEM_3, "C", 47.162, 27.600)
-        );
+                new RoutePoint(ITEM_3, "C", 47.162, 27.600));
 
         List<RoutePoint> improved = optimizer.threeOptImprove(route);
 
@@ -168,8 +164,10 @@ class RoutingServiceTest {
         when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
                 .thenReturn(List.of(STORE_ID));
 
-        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871, 0.9);
-        RoutingService.ProductLocation p2 = new RoutingService.ProductLocation(ITEM_2, "Produs 2", 47.1558, 27.5865, 0.8);
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871,
+                0.9);
+        RoutingService.ProductLocation p2 = new RoutingService.ProductLocation(ITEM_2, "Produs 2", 47.1558, 27.5865,
+                0.8);
 
         when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
                 .thenReturn(List.of(p1, p2));
@@ -197,11 +195,10 @@ class RoutingServiceTest {
                 new RoutingService.ProductLocation("item5", "P5", 47.1550, 27.5850, 0.8),
                 new RoutingService.ProductLocation("item6", "P6", 47.1548, 27.5845, 0.7),
                 new RoutingService.ProductLocation("item7", "P7", 47.1546, 27.5840, 0.9),
-                new RoutingService.ProductLocation("item8", "P8", 47.1544, 27.5835, 0.8)
-        );
+                new RoutingService.ProductLocation("item8", "P8", 47.1544, 27.5835, 0.8));
         when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
                 .thenReturn(locations);
-        
+
         ValueOperations<String, String> valueOps = mock(ValueOperations.class);
         when(redis.opsForValue()).thenReturn(valueOps);
 
@@ -229,8 +226,7 @@ class RoutingServiceTest {
     void routeDistance_shouldReturnPositiveForMultiplePoints() {
         List<RoutePoint> route = List.of(
                 new RoutePoint("u", "Tu", 47.156, 27.587),
-                new RoutePoint(ITEM_1, "A", 47.160, 27.595)
-        );
+                new RoutePoint(ITEM_1, "A", 47.160, 27.595));
         assertTrue(optimizer.routeDistance(route) > 0);
     }
 
@@ -240,7 +236,8 @@ class RoutingServiceTest {
         when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
                 .thenReturn(List.of(STORE_ID));
 
-        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871, 0.0);
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871,
+                0.0);
         when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
                 .thenReturn(List.of(p1));
 
@@ -252,9 +249,6 @@ class RoutingServiceTest {
         assertTrue(response.getWarnings().stream().anyMatch(w -> w.contains("incredere scazut")));
     }
 
-    // -------------------------------------------------------------------------
-    // Issue 154
-    // -------------------------------------------------------------------------
     @Test
     @SuppressWarnings("unchecked")
     void calculateOptimalRoute_shouldHandleEmptyResultExceptionFromExitPoint() {
@@ -332,11 +326,13 @@ class RoutingServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void calculateOptimalRoute_shouldExposeRouteMetrics() {
         when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
                 .thenReturn(List.of(STORE_ID));
 
-        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871, 0.9);
+        RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "Produs 1", 47.1562, 27.5871,
+                0.9);
         when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
                 .thenReturn(List.of(p1));
 

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -360,4 +360,83 @@ class RoutingServiceTest {
         RoutePoint user = new RoutePoint("user_loc", "Tu", 47.156, 27.587, "USER");
         assertEquals("USER", user.getType());
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void calculateOptimalRoute_shouldFallbackToRawPingsWhenInventoryMapIsEmpty() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        // First query (inventory map) returns empty, second (raw pings) returns results
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of())
+                .thenReturn(List.of(new RoutingService.ProductLocation(ITEM_1, "Raw Product", 47.1, 27.1, 0.0)));
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        assertTrue(response.getWarnings().stream().anyMatch(w -> w.contains("estimate din date brute")));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void fetchExitPoint_shouldHandleGenericException() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(new RoutingService.ProductLocation(ITEM_1, "P1", 47.1, 27.1, 0.9)));
+
+        when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), anyString()))
+                .thenThrow(new RuntimeException("DB error"));
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        assertEquals(2, response.getRoute().size()); // User + Product, no checkout
+    }
+
+    @Test
+    void calculateOptimalRoute_shouldHandleNullProductIds() {
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, null, 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("error", response.getStatus());
+        assertTrue(response.getWarnings().contains("Nu esti in niciun magazin cunoscut."));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void calculateOptimalRoute_shouldReturnErrorIfNoProductsFoundInBothSources() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of())
+                .thenReturn(List.of());
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("error", response.getStatus());
+        assertTrue(response.getWarnings().contains("Niciunul din produsele cerute nu a fost gasit in magazin."));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void calculateOptimalRoute_shouldNotGoLazyIfRouteIsShort() {
+        when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(STORE_ID));
+
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(new RoutingService.ProductLocation(ITEM_1, "P1", 47.1, 27.1, 0.9)));
+
+        RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 10);
+        RoutingResponse response = service.calculateOptimalRoute(request);
+
+        assertEquals("success", response.getStatus());
+        assertFalse(response.isPartial());
+    }
 }

--- a/src/test/java/com/p2ps/service/RoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/RoutingServiceTest.java
@@ -126,6 +126,7 @@ class RoutingServiceTest {
         assertTrue(after <= before + 1e-9);
         assertEquals(route.size(), improved.size());
     }
+    
 
     @Test
     void threeOptImprove_shouldReturnAllSamePoints() {
@@ -252,9 +253,28 @@ class RoutingServiceTest {
     }
 
     // -------------------------------------------------------------------------
-    // Issue #154 — Closed-Loop TSP (start = user, end = checkout)
+    // Issue 154
     // -------------------------------------------------------------------------
+    @Test
+    @SuppressWarnings("unchecked")
+        void calculateOptimalRoute_shouldHandleEmptyResultExceptionFromExitPoint() {
+    when(jdbcTemplate.queryForList(anyString(), eq(String.class), anyDouble(), anyDouble()))
+            .thenReturn(List.of(STORE_ID));
 
+    RoutingService.ProductLocation p1 = new RoutingService.ProductLocation(ITEM_1, "P1", 47.1562, 27.5871, 0.9);
+    when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+            .thenReturn(List.of(p1));
+
+    when(jdbcTemplate.queryForObject(anyString(), any(RowMapper.class), anyString()))
+            .thenThrow(new org.springframework.dao.EmptyResultDataAccessException(1));
+
+    RoutingRequest request = new RoutingRequest(47.156, 27.587, List.of(ITEM_1), 0);
+    RoutingResponse response = service.calculateOptimalRoute(request);
+
+    assertEquals("success", response.getStatus());
+    RoutePoint last = response.getRoute().get(response.getRoute().size() - 1);
+    assertNotEquals("checkout", last.getItemId());
+    }
     @Test
     @SuppressWarnings("unchecked")
     void calculateOptimalRoute_shouldEndAtCheckoutWhenExitPointExists() {


### PR DESCRIPTION
Modifies the routing algorithm from an open Hamiltonian path into a closed loop that starts at the user's location and ends at the store's checkout counters.

Changes:
- Added entry_point and exit_point columns to store_geofences (04-add-store-entry-exit-points.sql)
- Populated sample coordinates for all 3 stores in 99-populare.sql
- RoutePoint: added `type` field ("USER" / "PRODUCT" / "CHECKOUT"), backward-compatible constructors
- RoutingService: fetchExitPoint() queries exit_point from store_geofences and pins it as the last node
- 3-opt already preserves first and last node — no changes needed to RouteOptimizer
- Graceful fallback: stores without exit_point configured return open-path route (backward compatible)
- 4 new unit tests in RoutingServiceTest

Verified via Postman: route[0].type == USER, route[last].type == CHECKOUT

Closes #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed-loop routing can end at a designated checkout/exit point when available; routing still works normally without an exit point.
  * Routes now consider store entry and exit locations for more accurate navigation.

* **Chores**
  * Database schema updated to add nullable entry/exit location columns and a spatial index to support efficient lookups.

* **Tests**
  * Added coverage for exit-point handling and route-point type behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->