### PR TITLE
feat: pending list invitations instead of direct collaborator mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ node_modules/
 dist/
 
 .local
+AGENTS.md

--- a/init-scripts/05-list-invitations.sql
+++ b/init-scripts/05-list-invitations.sql
@@ -7,9 +7,10 @@ CREATE TABLE IF NOT EXISTS list_invitations (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_invitation_list FOREIGN KEY (shopping_list_id) REFERENCES shopping_lists(id) ON DELETE CASCADE,
     CONSTRAINT fk_invitation_inviter FOREIGN KEY (inviter_id) REFERENCES users(id) ON DELETE CASCADE,
-    CONSTRAINT fk_invitation_invitee FOREIGN KEY (invitee_id) REFERENCES users(id) ON DELETE CASCADE,
-    CONSTRAINT uq_invitation_list_invitee UNIQUE(shopping_list_id, invitee_id)
+    CONSTRAINT fk_invitation_invitee FOREIGN KEY (invitee_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX uq_invitation_list_invitee_pending ON list_invitations(shopping_list_id, invitee_id) WHERE status = 'PENDING';
 
 CREATE INDEX IF NOT EXISTS idx_invitations_invitee ON list_invitations(invitee_id);
 CREATE INDEX IF NOT EXISTS idx_invitations_list ON list_invitations(shopping_list_id);

--- a/init-scripts/05-list-invitations.sql
+++ b/init-scripts/05-list-invitations.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS list_invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    shopping_list_id UUID NOT NULL,
+    inviter_id INTEGER NOT NULL,
+    invitee_id INTEGER NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_invitation_list FOREIGN KEY (shopping_list_id) REFERENCES shopping_lists(id) ON DELETE CASCADE,
+    CONSTRAINT fk_invitation_inviter FOREIGN KEY (inviter_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_invitation_invitee FOREIGN KEY (invitee_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT uq_invitation_list_invitee UNIQUE(shopping_list_id, invitee_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_invitee ON list_invitations(invitee_id);
+CREATE INDEX IF NOT EXISTS idx_invitations_list ON list_invitations(shopping_list_id);

--- a/src/main/java/com/p2ps/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/p2ps/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.p2ps.exception;
 
+import com.p2ps.lists.exception.InvitationNotFoundException;
 import com.p2ps.lists.exception.ItemNotFoundException;
 import com.p2ps.lists.exception.ListAccessDeniedException;
 import com.p2ps.lists.exception.ListUserNotFoundException;
@@ -67,7 +68,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler({ItemNotFoundException.class, ShoppingListNotFoundException.class})
+    @ExceptionHandler({ItemNotFoundException.class, ShoppingListNotFoundException.class, InvitationNotFoundException.class})
     public ResponseEntity<ErrorResponse> handleNotFoundExceptions(RuntimeException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
                 "Resource Not Found",

--- a/src/main/java/com/p2ps/lists/controller/InvitationController.java
+++ b/src/main/java/com/p2ps/lists/controller/InvitationController.java
@@ -1,0 +1,43 @@
+package com.p2ps.lists.controller;
+
+import com.p2ps.lists.dto.ListInvitationDTO;
+import com.p2ps.lists.service.InvitationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/invitations")
+public class InvitationController {
+
+    private final InvitationService invitationService;
+
+    public InvitationController(InvitationService invitationService) {
+        this.invitationService = invitationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ListInvitationDTO>> getPendingInvitations(Authentication authentication) {
+        List<ListInvitationDTO> invitations = invitationService.getPendingInvitations(authentication.getName());
+        return ResponseEntity.ok(invitations);
+    }
+
+    @PostMapping("/{invitationId}/accept")
+    public ResponseEntity<Void> acceptInvitation(
+            @PathVariable UUID invitationId,
+            Authentication authentication) {
+        invitationService.acceptInvitation(invitationId, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{invitationId}/decline")
+    public ResponseEntity<Void> declineInvitation(
+            @PathVariable UUID invitationId,
+            Authentication authentication) {
+        invitationService.declineInvitation(invitationId, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/p2ps/lists/dto/ListInvitationDTO.java
+++ b/src/main/java/com/p2ps/lists/dto/ListInvitationDTO.java
@@ -1,0 +1,18 @@
+package com.p2ps.lists.dto;
+
+import com.p2ps.lists.model.InvitationStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+public class ListInvitationDTO {
+    private UUID id;
+    private UUID listId;
+    private String listTitle;
+    private String inviterName;
+    private String inviterEmail;
+    private InvitationStatus status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/p2ps/lists/exception/InvitationNotFoundException.java
+++ b/src/main/java/com/p2ps/lists/exception/InvitationNotFoundException.java
@@ -1,0 +1,8 @@
+package com.p2ps.lists.exception;
+
+public class InvitationNotFoundException extends RuntimeException {
+
+    public InvitationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/p2ps/lists/model/InvitationStatus.java
+++ b/src/main/java/com/p2ps/lists/model/InvitationStatus.java
@@ -1,0 +1,7 @@
+package com.p2ps.lists.model;
+
+public enum InvitationStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED
+}

--- a/src/main/java/com/p2ps/lists/model/ListInvitation.java
+++ b/src/main/java/com/p2ps/lists/model/ListInvitation.java
@@ -1,0 +1,44 @@
+package com.p2ps.lists.model;
+
+import com.p2ps.auth.model.Users;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "list_invitations")
+@Getter
+@Setter
+public class ListInvitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shopping_list_id", nullable = false)
+    private ShoppingList shoppingList;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private Users inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id", nullable = false)
+    private Users invitee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private InvitationStatus status = InvitationStatus.PENDING;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/p2ps/lists/repo/ListInvitationRepository.java
+++ b/src/main/java/com/p2ps/lists/repo/ListInvitationRepository.java
@@ -1,0 +1,23 @@
+package com.p2ps.lists.repo;
+
+import com.p2ps.lists.model.InvitationStatus;
+import com.p2ps.lists.model.ListInvitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ListInvitationRepository extends JpaRepository<ListInvitation, UUID> {
+
+    @Query("SELECT i FROM ListInvitation i LEFT JOIN FETCH i.shoppingList LEFT JOIN FETCH i.inviter WHERE i.invitee.email = :email AND i.status = :status")
+    List<ListInvitation> findByInviteeEmailAndStatus(@Param("email") String email, @Param("status") InvitationStatus status);
+
+    Optional<ListInvitation> findByShoppingListIdAndInviteeId(UUID listId, Integer inviteeId);
+
+    boolean existsByShoppingListIdAndInviteeIdAndStatus(UUID listId, Integer inviteeId, InvitationStatus status);
+}

--- a/src/main/java/com/p2ps/lists/service/InvitationService.java
+++ b/src/main/java/com/p2ps/lists/service/InvitationService.java
@@ -1,0 +1,93 @@
+package com.p2ps.lists.service;
+
+import com.p2ps.auth.model.Users;
+import com.p2ps.auth.repository.UserRepository;
+import com.p2ps.lists.dto.ListInvitationDTO;
+import com.p2ps.lists.exception.ListAccessDeniedException;
+import com.p2ps.lists.exception.ListUserNotFoundException;
+import com.p2ps.lists.exception.ShoppingListNotFoundException;
+import com.p2ps.lists.model.InvitationStatus;
+import com.p2ps.lists.model.ListInvitation;
+import com.p2ps.lists.model.ShoppingList;
+import com.p2ps.lists.repo.ListInvitationRepository;
+import com.p2ps.lists.repo.ShoppingListRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class InvitationService {
+
+    private final ListInvitationRepository invitationRepository;
+    private final ShoppingListRepository shoppingListRepository;
+    private final UserRepository userRepository;
+
+    public InvitationService(ListInvitationRepository invitationRepository,
+                             ShoppingListRepository shoppingListRepository,
+                             UserRepository userRepository) {
+        this.invitationRepository = invitationRepository;
+        this.shoppingListRepository = shoppingListRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ListInvitationDTO> getPendingInvitations(String userEmail) {
+        return invitationRepository.findByInviteeEmailAndStatus(userEmail, InvitationStatus.PENDING)
+                .stream()
+                .map(this::mapToDTO)
+                .toList();
+    }
+
+    @Transactional
+    public void acceptInvitation(UUID invitationId, String userEmail) {
+        ListInvitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new ShoppingListNotFoundException("Invitation not found"));
+
+        if (!invitation.getInvitee().getEmail().equals(userEmail)) {
+            throw new ListAccessDeniedException("This invitation is not for you");
+        }
+
+        if (invitation.getStatus() != InvitationStatus.PENDING) {
+            throw new ListAccessDeniedException("Invitation is no longer pending");
+        }
+
+        ShoppingList list = invitation.getShoppingList();
+        list.getCollaborators().add(invitation.getInvitee());
+        shoppingListRepository.save(list);
+
+        invitation.setStatus(InvitationStatus.ACCEPTED);
+        invitationRepository.save(invitation);
+    }
+
+    @Transactional
+    public void declineInvitation(UUID invitationId, String userEmail) {
+        ListInvitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new ShoppingListNotFoundException("Invitation not found"));
+
+        if (!invitation.getInvitee().getEmail().equals(userEmail)) {
+            throw new ListAccessDeniedException("This invitation is not for you");
+        }
+
+        if (invitation.getStatus() != InvitationStatus.PENDING) {
+            throw new ListAccessDeniedException("Invitation is no longer pending");
+        }
+
+        invitation.setStatus(InvitationStatus.DECLINED);
+        invitationRepository.save(invitation);
+    }
+
+    private ListInvitationDTO mapToDTO(ListInvitation invitation) {
+        ListInvitationDTO dto = new ListInvitationDTO();
+        dto.setId(invitation.getId());
+        dto.setListId(invitation.getShoppingList().getId());
+        dto.setListTitle(invitation.getShoppingList().getTitle());
+        dto.setInviterName(invitation.getInviter().getFirstName() + " " + invitation.getInviter().getLastName());
+        String email = invitation.getInviter().getEmail();
+        dto.setInviterEmail(email.replaceAll("(^.)[^@]*(@.*$)", "$1***$2"));
+        dto.setStatus(invitation.getStatus());
+        dto.setCreatedAt(invitation.getCreatedAt());
+        return dto;
+    }
+}

--- a/src/main/java/com/p2ps/lists/service/InvitationService.java
+++ b/src/main/java/com/p2ps/lists/service/InvitationService.java
@@ -1,11 +1,10 @@
 package com.p2ps.lists.service;
 
 import com.p2ps.auth.model.Users;
-import com.p2ps.auth.repository.UserRepository;
 import com.p2ps.lists.dto.ListInvitationDTO;
+import com.p2ps.lists.exception.InvitationNotFoundException;
 import com.p2ps.lists.exception.ListAccessDeniedException;
 import com.p2ps.lists.exception.ListUserNotFoundException;
-import com.p2ps.lists.exception.ShoppingListNotFoundException;
 import com.p2ps.lists.model.InvitationStatus;
 import com.p2ps.lists.model.ListInvitation;
 import com.p2ps.lists.model.ShoppingList;
@@ -22,14 +21,11 @@ public class InvitationService {
 
     private final ListInvitationRepository invitationRepository;
     private final ShoppingListRepository shoppingListRepository;
-    private final UserRepository userRepository;
 
     public InvitationService(ListInvitationRepository invitationRepository,
-                             ShoppingListRepository shoppingListRepository,
-                             UserRepository userRepository) {
+                             ShoppingListRepository shoppingListRepository) {
         this.invitationRepository = invitationRepository;
         this.shoppingListRepository = shoppingListRepository;
-        this.userRepository = userRepository;
     }
 
     @Transactional(readOnly = true)
@@ -43,7 +39,7 @@ public class InvitationService {
     @Transactional
     public void acceptInvitation(UUID invitationId, String userEmail) {
         ListInvitation invitation = invitationRepository.findById(invitationId)
-                .orElseThrow(() -> new ShoppingListNotFoundException("Invitation not found"));
+                .orElseThrow(() -> new InvitationNotFoundException("Invitation not found"));
 
         if (!invitation.getInvitee().getEmail().equals(userEmail)) {
             throw new ListAccessDeniedException("This invitation is not for you");
@@ -64,7 +60,7 @@ public class InvitationService {
     @Transactional
     public void declineInvitation(UUID invitationId, String userEmail) {
         ListInvitation invitation = invitationRepository.findById(invitationId)
-                .orElseThrow(() -> new ShoppingListNotFoundException("Invitation not found"));
+                .orElseThrow(() -> new InvitationNotFoundException("Invitation not found"));
 
         if (!invitation.getInvitee().getEmail().equals(userEmail)) {
             throw new ListAccessDeniedException("This invitation is not for you");

--- a/src/main/java/com/p2ps/lists/service/ShoppingListService.java
+++ b/src/main/java/com/p2ps/lists/service/ShoppingListService.java
@@ -11,10 +11,13 @@ import com.p2ps.lists.dto.ShoppingListDTO;
 import com.p2ps.lists.exception.ListAccessDeniedException;
 import com.p2ps.lists.exception.ListUserNotFoundException;
 import com.p2ps.lists.exception.ShoppingListNotFoundException;
+import com.p2ps.lists.model.InvitationStatus;
 import com.p2ps.lists.model.Item;
 import com.p2ps.lists.model.ListCategory;
+import com.p2ps.lists.model.ListInvitation;
 import com.p2ps.lists.model.ShoppingList;
 import com.p2ps.lists.repo.ItemRepository;
+import com.p2ps.lists.repo.ListInvitationRepository;
 import com.p2ps.lists.repo.ShoppingListRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,13 +31,15 @@ public class ShoppingListService {
 
     private final ShoppingListRepository shoppingListRepository;
     private final UserRepository userRepository;
+    private final ListInvitationRepository invitationRepository;
     private static final String SHOPPING_LIST_NOT_FOUND = "Shopping list not found";
     private final ItemRepository itemRepository;
 
-    public ShoppingListService(ShoppingListRepository shoppingListRepository, UserRepository userRepository, ItemRepository itemRepository) {
+    public ShoppingListService(ShoppingListRepository shoppingListRepository, UserRepository userRepository, ItemRepository itemRepository, ListInvitationRepository invitationRepository) {
         this.shoppingListRepository = shoppingListRepository;
         this.userRepository = userRepository;
         this.itemRepository = itemRepository;
+        this.invitationRepository = invitationRepository;
     }
 
     @Transactional
@@ -279,8 +284,22 @@ public class ShoppingListService {
         Users collaborator = userRepository.findByEmail(collaboratorEmail)
                 .orElseThrow(() -> new ListUserNotFoundException("Collaborator user not found"));
 
-        list.getCollaborators().add(collaborator);
-        shoppingListRepository.save(list);
+        if (list.getCollaborators().stream().anyMatch(c -> c.getId().equals(collaborator.getId()))) {
+            throw new IllegalArgumentException("User is already a collaborator on this list");
+        }
+
+        boolean alreadyInvited = invitationRepository.existsByShoppingListIdAndInviteeIdAndStatus(
+                listId, collaborator.getId(), InvitationStatus.PENDING);
+        if (alreadyInvited) {
+            throw new IllegalArgumentException("Invitation already pending for this user");
+        }
+
+        ListInvitation invitation = new ListInvitation();
+        invitation.setShoppingList(list);
+        invitation.setInviter(list.getUser());
+        invitation.setInvitee(collaborator);
+        invitation.setStatus(InvitationStatus.PENDING);
+        invitationRepository.save(invitation);
     }
 
     private ShoppingListDTO mapToDTO(ShoppingList list) {

--- a/src/main/java/com/p2ps/lists/service/ShoppingListService.java
+++ b/src/main/java/com/p2ps/lists/service/ShoppingListService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -288,10 +289,21 @@ public class ShoppingListService {
             throw new IllegalArgumentException("User is already a collaborator on this list");
         }
 
-        boolean alreadyInvited = invitationRepository.existsByShoppingListIdAndInviteeIdAndStatus(
-                listId, collaborator.getId(), InvitationStatus.PENDING);
-        if (alreadyInvited) {
-            throw new IllegalArgumentException("Invitation already pending for this user");
+        Optional<ListInvitation> existingInvitation = invitationRepository.findByShoppingListIdAndInviteeId(
+                listId, collaborator.getId());
+
+        if (existingInvitation.isPresent()) {
+            ListInvitation existing = existingInvitation.get();
+            if (existing.getStatus() == InvitationStatus.PENDING) {
+                throw new IllegalArgumentException("Invitation already pending for this user");
+            }
+            if (existing.getStatus() == InvitationStatus.ACCEPTED) {
+                throw new IllegalArgumentException("User has already accepted an invitation for this list");
+            }
+            existing.setInviter(list.getUser());
+            existing.setStatus(InvitationStatus.PENDING);
+            invitationRepository.save(existing);
+            return;
         }
 
         ListInvitation invitation = new ListInvitation();

--- a/src/test/java/com/p2ps/lists/controller/InvitationControllerTest.java
+++ b/src/test/java/com/p2ps/lists/controller/InvitationControllerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -21,8 +20,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/p2ps/lists/controller/InvitationControllerTest.java
+++ b/src/test/java/com/p2ps/lists/controller/InvitationControllerTest.java
@@ -1,0 +1,149 @@
+package com.p2ps.lists.controller;
+
+import com.p2ps.exception.GlobalExceptionHandler;
+import com.p2ps.lists.dto.ListInvitationDTO;
+import com.p2ps.lists.exception.InvitationNotFoundException;
+import com.p2ps.lists.exception.ListAccessDeniedException;
+import com.p2ps.lists.model.InvitationStatus;
+import com.p2ps.lists.service.InvitationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationControllerTest {
+
+    @Mock
+    private InvitationService invitationService;
+
+    @InjectMocks
+    private InvitationController invitationController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(invitationController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void getPendingInvitationsShouldReturnList() throws Exception {
+        UUID invId = UUID.randomUUID();
+        ListInvitationDTO dto = new ListInvitationDTO();
+        dto.setId(invId);
+        dto.setListTitle("Groceries");
+        dto.setInviterName("Owner User");
+        dto.setInviterEmail("o***@example.com");
+        dto.setStatus(InvitationStatus.PENDING);
+        dto.setCreatedAt(LocalDateTime.now());
+
+        when(invitationService.getPendingInvitations("invitee@example.com"))
+                .thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/invitations")
+                        .principal(new UsernamePasswordAuthenticationToken("invitee@example.com", null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(invId.toString()))
+                .andExpect(jsonPath("$[0].listTitle").value("Groceries"))
+                .andExpect(jsonPath("$[0].status").value("PENDING"));
+
+        verify(invitationService).getPendingInvitations("invitee@example.com");
+    }
+
+    @Test
+    void getPendingInvitationsShouldReturnEmptyList() throws Exception {
+        when(invitationService.getPendingInvitations("nobody@example.com"))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/invitations")
+                        .principal(new UsernamePasswordAuthenticationToken("nobody@example.com", null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void acceptInvitationShouldReturnNoContent() throws Exception {
+        UUID invId = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/invitations/{invitationId}/accept", invId)
+                        .principal(new UsernamePasswordAuthenticationToken("invitee@example.com", null)))
+                .andExpect(status().isNoContent());
+
+        verify(invitationService).acceptInvitation(invId, "invitee@example.com");
+    }
+
+    @Test
+    void acceptInvitationShouldReturnNotFoundWhenMissing() throws Exception {
+        UUID invId = UUID.randomUUID();
+
+        doThrow(new InvitationNotFoundException("Invitation not found"))
+                .when(invitationService).acceptInvitation(invId, "invitee@example.com");
+
+        mockMvc.perform(post("/api/invitations/{invitationId}/accept", invId)
+                        .principal(new UsernamePasswordAuthenticationToken("invitee@example.com", null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Resource Not Found"))
+                .andExpect(jsonPath("$.details").value("Invitation not found"));
+    }
+
+    @Test
+    void acceptInvitationShouldReturnForbiddenForWrongUser() throws Exception {
+        UUID invId = UUID.randomUUID();
+
+        doThrow(new ListAccessDeniedException("This invitation is not for you"))
+                .when(invitationService).acceptInvitation(invId, "wrong@example.com");
+
+        mockMvc.perform(post("/api/invitations/{invitationId}/accept", invId)
+                        .principal(new UsernamePasswordAuthenticationToken("wrong@example.com", null)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Forbidden"));
+    }
+
+    @Test
+    void declineInvitationShouldReturnNoContent() throws Exception {
+        UUID invId = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/invitations/{invitationId}/decline", invId)
+                        .principal(new UsernamePasswordAuthenticationToken("invitee@example.com", null)))
+                .andExpect(status().isNoContent());
+
+        verify(invitationService).declineInvitation(invId, "invitee@example.com");
+    }
+
+    @Test
+    void declineInvitationShouldReturnNotFoundWhenMissing() throws Exception {
+        UUID invId = UUID.randomUUID();
+
+        doThrow(new InvitationNotFoundException("Invitation not found"))
+                .when(invitationService).declineInvitation(invId, "invitee@example.com");
+
+        mockMvc.perform(post("/api/invitations/{invitationId}/decline", invId)
+                        .principal(new UsernamePasswordAuthenticationToken("invitee@example.com", null)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Resource Not Found"));
+    }
+}

--- a/src/test/java/com/p2ps/lists/model/ListInvitationTest.java
+++ b/src/test/java/com/p2ps/lists/model/ListInvitationTest.java
@@ -1,0 +1,57 @@
+package com.p2ps.lists.model;
+
+import com.p2ps.auth.model.Users;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListInvitationTest {
+
+    @Test
+    void testGettersSetters() {
+        ListInvitation inv = new ListInvitation();
+        UUID id = UUID.randomUUID();
+        inv.setId(id);
+
+        Users inviter = new Users();
+        inviter.setId(1);
+        Users invitee = new Users();
+        invitee.setId(2);
+
+        ShoppingList list = new ShoppingList();
+        list.setId(UUID.randomUUID());
+
+        inv.setShoppingList(list);
+        inv.setInviter(inviter);
+        inv.setInvitee(invitee);
+        inv.setStatus(InvitationStatus.DECLINED);
+
+        assertThat(inv.getId()).isEqualTo(id);
+        assertThat(inv.getShoppingList()).isEqualTo(list);
+        assertThat(inv.getInviter()).isEqualTo(inviter);
+        assertThat(inv.getInvitee()).isEqualTo(invitee);
+        assertThat(inv.getStatus()).isEqualTo(InvitationStatus.DECLINED);
+    }
+
+    @Test
+    void defaultStatusShouldBePending() {
+        ListInvitation inv = new ListInvitation();
+        assertThat(inv.getStatus()).isEqualTo(InvitationStatus.PENDING);
+    }
+
+    @Test
+    void onCreateShouldSetCreatedAt() throws Exception {
+        ListInvitation inv = new ListInvitation();
+        assertThat(inv.getCreatedAt()).isNull();
+
+        Method onCreate = ListInvitation.class.getDeclaredMethod("onCreate");
+        onCreate.setAccessible(true);
+        onCreate.invoke(inv);
+
+        assertThat(inv.getCreatedAt()).isNotNull();
+        assertThat(inv.getCreatedAt()).isBeforeOrEqualTo(java.time.LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/p2ps/lists/service/InvitationServiceTest.java
+++ b/src/test/java/com/p2ps/lists/service/InvitationServiceTest.java
@@ -1,0 +1,235 @@
+package com.p2ps.lists.service;
+
+import com.p2ps.auth.model.Users;
+import com.p2ps.lists.dto.ListInvitationDTO;
+import com.p2ps.lists.exception.InvitationNotFoundException;
+import com.p2ps.lists.exception.ListAccessDeniedException;
+import com.p2ps.lists.model.InvitationStatus;
+import com.p2ps.lists.model.ListInvitation;
+import com.p2ps.lists.model.ShoppingList;
+import com.p2ps.lists.repo.ListInvitationRepository;
+import com.p2ps.lists.repo.ShoppingListRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationServiceTest {
+
+    @Mock
+    private ListInvitationRepository invitationRepository;
+
+    @Mock
+    private ShoppingListRepository shoppingListRepository;
+
+    @InjectMocks
+    private InvitationService invitationService;
+
+    private Users createUser(Integer id, String email) {
+        Users user = new Users(email, "pass", "First", "Last");
+        user.setId(id);
+        return user;
+    }
+
+    private ShoppingList createList(UUID id, Users owner) {
+        ShoppingList list = new ShoppingList();
+        list.setId(id);
+        list.setTitle("Test List");
+        list.setUser(owner);
+        return list;
+    }
+
+    private ListInvitation createInvitation(UUID id, ShoppingList list, Users inviter, Users invitee, InvitationStatus status) {
+        ListInvitation inv = new ListInvitation();
+        inv.setId(id);
+        inv.setShoppingList(list);
+        inv.setInviter(inviter);
+        inv.setInvitee(invitee);
+        inv.setStatus(status);
+        return inv;
+    }
+
+    @Test
+    void getPendingInvitationsShouldReturnOnlyPendingForInvitee() {
+        String inviteeEmail = "invitee@example.com";
+        UUID listId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, inviteeEmail);
+
+        ShoppingList list = createList(listId, owner);
+        UUID invId = UUID.randomUUID();
+        ListInvitation pending = createInvitation(invId, list, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findByInviteeEmailAndStatus(inviteeEmail, InvitationStatus.PENDING))
+                .thenReturn(List.of(pending));
+
+        List<ListInvitationDTO> result = invitationService.getPendingInvitations(inviteeEmail);
+
+        assertEquals(1, result.size());
+        ListInvitationDTO dto = result.get(0);
+        assertEquals(invId, dto.getId());
+        assertEquals(listId, dto.getListId());
+        assertEquals("Test List", dto.getListTitle());
+        assertEquals("First Last", dto.getInviterName());
+        assertEquals("o***@example.com", dto.getInviterEmail());
+        assertEquals(InvitationStatus.PENDING, dto.getStatus());
+        assertEquals(pending.getCreatedAt(), dto.getCreatedAt());
+    }
+
+    @Test
+    void getPendingInvitationsShouldReturnMultipleResults() {
+        String inviteeEmail = "invitee@example.com";
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, inviteeEmail);
+
+        ShoppingList list1 = createList(UUID.randomUUID(), owner);
+        ShoppingList list2 = createList(UUID.randomUUID(), owner);
+        ListInvitation inv1 = createInvitation(UUID.randomUUID(), list1, owner, invitee, InvitationStatus.PENDING);
+        ListInvitation inv2 = createInvitation(UUID.randomUUID(), list2, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findByInviteeEmailAndStatus(inviteeEmail, InvitationStatus.PENDING))
+                .thenReturn(List.of(inv1, inv2));
+
+        List<ListInvitationDTO> result = invitationService.getPendingInvitations(inviteeEmail);
+
+        assertEquals(2, result.size());
+        assertEquals(list1.getId(), result.get(0).getListId());
+        assertEquals(list2.getId(), result.get(1).getListId());
+    }
+
+    @Test
+    void getPendingInvitationsShouldReturnEmptyWhenNone() {
+        when(invitationRepository.findByInviteeEmailAndStatus("nobody@example.com", InvitationStatus.PENDING))
+                .thenReturn(List.of());
+
+        List<ListInvitationDTO> result = invitationService.getPendingInvitations("nobody@example.com");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void acceptInvitationShouldAddCollaboratorAndSetAccepted() {
+        UUID invId = UUID.randomUUID();
+        UUID listId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(listId, owner);
+
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+        when(shoppingListRepository.save(any(ShoppingList.class))).thenAnswer(i -> i.getArgument(0));
+        when(invitationRepository.save(any(ListInvitation.class))).thenAnswer(i -> i.getArgument(0));
+
+        invitationService.acceptInvitation(invId, "invitee@example.com");
+
+        assertTrue(list.getCollaborators().contains(invitee));
+        assertEquals(InvitationStatus.ACCEPTED, invitation.getStatus());
+        verify(shoppingListRepository).save(list);
+        verify(invitationRepository).save(invitation);
+    }
+
+    @Test
+    void acceptInvitationShouldThrowForNonInvitee() {
+        UUID invId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(UUID.randomUUID(), owner);
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+
+        assertThrows(ListAccessDeniedException.class,
+                () -> invitationService.acceptInvitation(invId, "wrong@example.com"));
+    }
+
+    @Test
+    void acceptInvitationShouldThrowWhenNotPending() {
+        UUID invId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(UUID.randomUUID(), owner);
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.ACCEPTED);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+
+        assertThrows(ListAccessDeniedException.class,
+                () -> invitationService.acceptInvitation(invId, "invitee@example.com"));
+    }
+
+    @Test
+    void acceptInvitationShouldThrowWhenNotFound() {
+        when(invitationRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        assertThrows(InvitationNotFoundException.class,
+                () -> invitationService.acceptInvitation(UUID.randomUUID(), "invitee@example.com"));
+    }
+
+    @Test
+    void declineInvitationShouldSetDeclinedAndNotModifyList() {
+        UUID invId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(UUID.randomUUID(), owner);
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+        when(invitationRepository.save(any(ListInvitation.class))).thenAnswer(i -> i.getArgument(0));
+
+        invitationService.declineInvitation(invId, "invitee@example.com");
+
+        assertEquals(InvitationStatus.DECLINED, invitation.getStatus());
+        assertTrue(list.getCollaborators().isEmpty());
+        verify(shoppingListRepository, never()).save(any(ShoppingList.class));
+    }
+
+    @Test
+    void declineInvitationShouldThrowForNonInvitee() {
+        UUID invId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(UUID.randomUUID(), owner);
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.PENDING);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+
+        assertThrows(ListAccessDeniedException.class,
+                () -> invitationService.declineInvitation(invId, "wrong@example.com"));
+    }
+
+    @Test
+    void declineInvitationShouldThrowWhenNotPending() {
+        UUID invId = UUID.randomUUID();
+        Users owner = createUser(1, "owner@example.com");
+        Users invitee = createUser(2, "invitee@example.com");
+        ShoppingList list = createList(UUID.randomUUID(), owner);
+        ListInvitation invitation = createInvitation(invId, list, owner, invitee, InvitationStatus.DECLINED);
+
+        when(invitationRepository.findById(invId)).thenReturn(Optional.of(invitation));
+
+        assertThrows(ListAccessDeniedException.class,
+                () -> invitationService.declineInvitation(invId, "invitee@example.com"));
+    }
+
+    @Test
+    void declineInvitationShouldThrowWhenNotFound() {
+        when(invitationRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        assertThrows(InvitationNotFoundException.class,
+                () -> invitationService.declineInvitation(UUID.randomUUID(), "invitee@example.com"));
+    }
+}

--- a/src/test/java/com/p2ps/lists/service/InvitationServiceTest.java
+++ b/src/test/java/com/p2ps/lists/service/InvitationServiceTest.java
@@ -175,8 +175,9 @@ class InvitationServiceTest {
     void acceptInvitationShouldThrowWhenNotFound() {
         when(invitationRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
 
+        UUID randomId = UUID.randomUUID();
         assertThrows(InvitationNotFoundException.class,
-                () -> invitationService.acceptInvitation(UUID.randomUUID(), "invitee@example.com"));
+                () -> invitationService.acceptInvitation(randomId, "invitee@example.com"));
     }
 
     @Test
@@ -229,7 +230,8 @@ class InvitationServiceTest {
     void declineInvitationShouldThrowWhenNotFound() {
         when(invitationRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
 
+        UUID randomId = UUID.randomUUID();
         assertThrows(InvitationNotFoundException.class,
-                () -> invitationService.declineInvitation(UUID.randomUUID(), "invitee@example.com"));
+                () -> invitationService.declineInvitation(randomId, "invitee@example.com"));
     }
 }

--- a/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
+++ b/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
@@ -441,13 +441,148 @@ class ShoppingListServiceTest {
         
         when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
         when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
-        when(invitationRepository.existsByShoppingListIdAndInviteeIdAndStatus(listId, 2, InvitationStatus.PENDING)).thenReturn(false);
+        when(invitationRepository.findByShoppingListIdAndInviteeId(listId, 2))
+                .thenReturn(Optional.empty());
         
         shoppingListService.shareList(listId, collabEmail, ownerEmail);
         
         assertFalse(list.getCollaborators().contains(collaborator));
         verify(invitationRepository).save(any(ListInvitation.class));
         verify(shoppingListRepository, never()).save(list);
+    }
+
+    @Test
+    void shareListShouldReinviteWhenPreviousInvitationDeclined() {
+        String ownerEmail = "owner@example.com";
+        String collabEmail = "collab@example.com";
+        UUID listId = UUID.randomUUID();
+
+        Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
+        Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
+
+        ShoppingList list = new ShoppingList();
+        list.setId(listId);
+        list.setUser(owner);
+
+        ListInvitation declinedInvitation = new ListInvitation();
+        declinedInvitation.setShoppingList(list);
+        declinedInvitation.setInviter(owner);
+        declinedInvitation.setInvitee(collaborator);
+        declinedInvitation.setStatus(InvitationStatus.DECLINED);
+
+        when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
+        when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
+        when(invitationRepository.findByShoppingListIdAndInviteeId(listId, 2))
+                .thenReturn(Optional.of(declinedInvitation));
+
+        shoppingListService.shareList(listId, collabEmail, ownerEmail);
+
+        assertEquals(InvitationStatus.PENDING, declinedInvitation.getStatus());
+        verify(invitationRepository).save(declinedInvitation);
+        verify(shoppingListRepository, never()).save(list);
+    }
+
+    @Test
+    void shareListShouldThrowWhenExistingInvitationIsAccepted() {
+        String ownerEmail = "owner@example.com";
+        String collabEmail = "collab@example.com";
+        UUID listId = UUID.randomUUID();
+
+        Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
+        Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
+
+        ShoppingList list = new ShoppingList();
+        list.setId(listId);
+        list.setUser(owner);
+
+        ListInvitation acceptedInvitation = new ListInvitation();
+        acceptedInvitation.setShoppingList(list);
+        acceptedInvitation.setInviter(owner);
+        acceptedInvitation.setInvitee(collaborator);
+        acceptedInvitation.setStatus(InvitationStatus.ACCEPTED);
+
+        when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
+        when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
+        when(invitationRepository.findByShoppingListIdAndInviteeId(listId, 2))
+                .thenReturn(Optional.of(acceptedInvitation));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> shoppingListService.shareList(listId, collabEmail, ownerEmail));
+
+        assertEquals("User has already accepted an invitation for this list", ex.getMessage());
+        verify(invitationRepository, never()).save(any(ListInvitation.class));
+    }
+
+    @Test
+    void shareListShouldThrowWhenExistingInvitationIsPending() {
+        String ownerEmail = "owner@example.com";
+        String collabEmail = "collab@example.com";
+        UUID listId = UUID.randomUUID();
+
+        Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
+        Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
+
+        ShoppingList list = new ShoppingList();
+        list.setId(listId);
+        list.setUser(owner);
+
+        ListInvitation pendingInvitation = new ListInvitation();
+        pendingInvitation.setShoppingList(list);
+        pendingInvitation.setInviter(owner);
+        pendingInvitation.setInvitee(collaborator);
+        pendingInvitation.setStatus(InvitationStatus.PENDING);
+
+        when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
+        when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
+        when(invitationRepository.findByShoppingListIdAndInviteeId(listId, 2))
+                .thenReturn(Optional.of(pendingInvitation));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> shoppingListService.shareList(listId, collabEmail, ownerEmail));
+
+        assertEquals("Invitation already pending for this user", ex.getMessage());
+        verify(invitationRepository, never()).save(any(ListInvitation.class));
+    }
+
+    @Test
+    void shareListShouldThrowWhenListNotFound() {
+        UUID listId = UUID.randomUUID();
+        when(shoppingListRepository.findById(listId)).thenReturn(Optional.empty());
+
+        assertThrows(ShoppingListNotFoundException.class,
+                () -> shoppingListService.shareList(listId, "collab@example.com", "owner@example.com"));
+    }
+
+    @Test
+    void shareListShouldThrowWhenUserIsAlreadyCollaborator() {
+        String ownerEmail = "owner@example.com";
+        String collabEmail = "collab@example.com";
+        UUID listId = UUID.randomUUID();
+
+        Users owner = new Users(ownerEmail, "pass", "Owner", "User");
+        owner.setId(1);
+        Users collaborator = new Users(collabEmail, "pass", "Collab", "User");
+        collaborator.setId(2);
+
+        ShoppingList list = new ShoppingList();
+        list.setId(listId);
+        list.setUser(owner);
+        list.getCollaborators().add(collaborator);
+
+        when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
+        when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> shoppingListService.shareList(listId, collabEmail, ownerEmail));
+
+        assertEquals("User is already a collaborator on this list", ex.getMessage());
+        verify(invitationRepository, never()).save(any(ListInvitation.class));
     }
 
     @Test

--- a/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
+++ b/src/test/java/com/p2ps/lists/service/ShoppingListServiceTest.java
@@ -11,8 +11,11 @@ import com.p2ps.lists.exception.ListUserNotFoundException;
 import com.p2ps.lists.exception.ShoppingListNotFoundException;
 import com.p2ps.lists.model.Item;
 import com.p2ps.lists.model.ListCategory;
+import com.p2ps.lists.model.InvitationStatus;
+import com.p2ps.lists.model.ListInvitation;
 import com.p2ps.lists.model.ShoppingList;
 import com.p2ps.lists.repo.ItemRepository;
+import com.p2ps.lists.repo.ListInvitationRepository;
 import com.p2ps.lists.repo.ShoppingListRepository;
 import com.p2ps.ai.dto.ParsedItemResponse;
 import com.p2ps.catalog.model.ProductCatalog;
@@ -52,6 +55,9 @@ class ShoppingListServiceTest {
 
     @Mock
     private ItemRepository itemRepository;
+
+    @Mock
+    private ListInvitationRepository invitationRepository;
 
     @InjectMocks
     private ShoppingListService shoppingListService;
@@ -419,7 +425,7 @@ class ShoppingListServiceTest {
         assertEquals(new BigDecimal("1.5"), result.getItems().get(0).getPrice());
     }
     @Test
-    void shareListShouldAddCollaboratorWhenCalledByOwner() {
+    void shareListShouldCreatePendingInvitationWhenCalledByOwner() {
         String ownerEmail = "owner@example.com";
         String collabEmail = "collab@example.com";
         UUID listId = UUID.randomUUID();
@@ -435,11 +441,13 @@ class ShoppingListServiceTest {
         
         when(shoppingListRepository.findById(listId)).thenReturn(Optional.of(list));
         when(userRepository.findByEmail(collabEmail)).thenReturn(Optional.of(collaborator));
+        when(invitationRepository.existsByShoppingListIdAndInviteeIdAndStatus(listId, 2, InvitationStatus.PENDING)).thenReturn(false);
         
         shoppingListService.shareList(listId, collabEmail, ownerEmail);
         
-        assertTrue(list.getCollaborators().contains(collaborator));
-        verify(shoppingListRepository).save(list);
+        assertFalse(list.getCollaborators().contains(collaborator));
+        verify(invitationRepository).save(any(ListInvitation.class));
+        verify(shoppingListRepository, never()).save(list);
     }
 
     @Test


### PR DESCRIPTION
- Add list_invitations table migration (05-list-invitations.sql)
- Create ListInvitation entity, InvitationStatus enum, ListInvitationRepository
- Create InvitationService with getPendingInvitations/accept/decline
- Create InvitationController with GET /api/invitations, POST accept/decline
- Update ShoppingListService.shareList() to create pending invite
- Update ShoppingListServiceTest to verify invitation creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced list invitation system enabling users to invite collaborators to shopping lists
  * Users can now view all pending invitations they've received
  * New actions available: accept or decline invitations to join shopping lists
  * List sharing workflow updated to use invitations instead of immediate collaboration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->