### PR TITLE
BE 3.2 — Macro-Routing Full OSRM Polyline

### DIFF
--- a/src/main/java/com/p2ps/client/OsrmClient.java
+++ b/src/main/java/com/p2ps/client/OsrmClient.java
@@ -7,9 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+
 import java.util.Locale;
-
-
 
 /**
  * BE 3.2 — thin HTTP wrapper around the OSRM Route API.
@@ -18,11 +17,12 @@ import java.util.Locale;
  *   "foot" → walking estimate
  *   "car"  → driving estimate
  *
- * Default base URL points to the public OSRM demo server (no key required).
- * For self-hosted OSRM in Docker, set osrm.base-url=http://osrm:5000 in application.properties.
+ * Returns distance, duration, and an Encoded Polyline string representing
+ * the actual road geometry (all turns and curves), ready to be drawn on a map.
  *
  * OSRM route endpoint format:
- *   GET {baseUrl}/route/v1/{profile}/{fromLng},{fromLat};{toLng},{toLat}?overview=false
+ *   GET {baseUrl}/route/v1/{profile}/{fromLng},{fromLat};{toLng},{toLat}
+ *       ?overview=full&geometries=polyline
  *
  * Note: OSRM uses longitude FIRST, then latitude — opposite of PostGIS convention.
  */
@@ -42,10 +42,17 @@ public class OsrmClient {
         this.objectMapper = objectMapper;
     }
 
-    public record TransportEstimate(double distanceM, double durationSeconds) {}
+    /**
+     * @param distanceM       straight-road distance in metres
+     * @param durationSeconds estimated travel time in seconds
+     * @param polyline        Encoded Polyline string — contains all turns/curves of the route.
+     *                        Null if OSRM did not return geometry.
+     *                        Frontend decodes this to draw the route on a map.
+     */
+    public record TransportEstimate(double distanceM, double durationSeconds, String polyline) {}
 
     /**
-     * Calls OSRM and returns distance + duration for the given profile.
+     * Calls OSRM and returns distance, duration, and polyline for the given profile.
      * Returns null if OSRM is unreachable or returns no route.
      *
      * @param profile "foot" or "car"
@@ -53,10 +60,11 @@ public class OsrmClient {
     public TransportEstimate getEstimate(double fromLat, double fromLng,
                                          double toLat,   double toLng,
                                          String profile) {
-        // OSRM: coordinates are lng,lat (not lat,lng)
         String coordinates = String.format(Locale.ROOT, "%f,%f;%f,%f", fromLng, fromLat, toLng, toLat);
 
-        String url = osrmBaseUrl + "/route/v1/" + profile + "/" + coordinates + "?overview=false";
+        // overview=full returns the complete geometry; geometries=polyline uses Encoded Polyline format
+        String url = osrmBaseUrl + "/route/v1/" + profile + "/" + coordinates
+                + "?overview=full&geometries=polyline";
 
         try {
             String response = restTemplate.getForObject(url, String.class);
@@ -64,20 +72,25 @@ public class OsrmClient {
 
             String code = root.path("code").asText();
             if (!"Ok".equals(code)) {
-                logger.warn("OSRM returned non-OK code '{}' for profile '{}': {}", code, profile, url);
+                logger.warn("OSRM returned non-OK code '{}' for profile '{}'", code, profile);
                 return null;
             }
 
             JsonNode route = root.path("routes").get(0);
             if (route == null || route.isMissingNode()) {
-                logger.warn("OSRM returned no routes for profile '{}': {}", profile, url);
+                logger.warn("OSRM returned no routes for profile '{}'", profile);
                 return null;
             }
 
             double distance = route.path("distance").asDouble();
             double duration = route.path("duration").asDouble();
-            logger.debug("OSRM [{}]: {}m in {}s", profile, Math.round(distance), Math.round(duration));
-            return new TransportEstimate(distance, duration);
+            String polyline = route.path("geometry").asText(null);
+
+            logger.debug("OSRM [{}]: {}m in {}s polyline={}", profile,
+                    Math.round(distance), Math.round(duration),
+                    polyline != null ? polyline.length() + " chars" : "null");
+
+            return new TransportEstimate(distance, duration, polyline);
 
         } catch (Exception e) {
             logger.warn("OSRM request failed for profile '{}': {}", profile, e.getMessage());

--- a/src/main/java/com/p2ps/controller/MacroRoutingResponse.java
+++ b/src/main/java/com/p2ps/controller/MacroRoutingResponse.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
  * BE 3.2 — response for GET /api/routing/macro
  *
  * Both walking and driving can be null independently if OSRM fails for that profile.
- * The frontend checks for null before rendering — this is intentional: a null estimate
- * means "unavailable" (e.g. no walking path exists), not an error.
+ * The polyline field contains an Encoded Polyline string that the frontend decodes
+ * to draw the actual road route on a map (not a straight line).
  */
 @Data
 @NoArgsConstructor
@@ -26,9 +26,15 @@ public class MacroRoutingResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TransportEstimate {
-        /** Straight-road distance in metres. */
+        /** Road distance in metres. */
         private double distanceM;
         /** Estimated travel time in seconds. */
         private double durationSeconds;
+        /**
+         * Encoded Polyline string — represents all turns and curves of the route on real roads.
+         * Frontend decodes this using a polyline library (e.g. @mapbox/polyline) to draw the route.
+         * Null if OSRM did not return geometry.
+         */
+        private String polyline;
     }
 }

--- a/src/main/java/com/p2ps/service/MacroRoutingService.java
+++ b/src/main/java/com/p2ps/service/MacroRoutingService.java
@@ -12,15 +12,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-
 /**
  * BE 3.2 — Macro-Routing (Walking vs Driving).
  *
- * Calculates the estimated distance and transit time from the user's current location
- * to the selected store's entrance. Returns separate estimates for foot and car.
+ * Calculates the estimated distance, transit time, and road geometry from the user's
+ * current location to the selected store's entrance.
+ * Returns separate estimates for foot and car, each including an Encoded Polyline
+ * for the frontend to draw the actual route on a map.
  *
  * Store entrance = ST_Centroid(boundary_polygon) from store_geofences.
- * No new DB column or Flyway migration needed.
  */
 @Service
 public class MacroRoutingService {
@@ -37,6 +37,7 @@ public class MacroRoutingService {
 
     /**
      * Returns walking and driving estimates from (userLat, userLng) to the store entrance.
+     * Each estimate includes distanceM, durationSeconds, and a polyline for map rendering.
      *
      * @param storeId UUID string — must match a store_geofences.store_id
      * @return MacroRoutingResponse with walking and driving fields (either can be null if OSRM fails)
@@ -50,9 +51,7 @@ public class MacroRoutingService {
 
         double storeLat = entrance[0];
         double storeLng = entrance[1];
-        if (logger.isInfoEnabled()) {
-            logger.info("Macro-routing: calculating estimates to store entrance for storeId={}", storeId.replaceAll("[\r\n]", ""));
-        }
+        logger.info("Macro-routing: calculating estimates to store entrance");
 
         CompletableFuture<OsrmClient.TransportEstimate> walkingFuture = CompletableFuture.supplyAsync(
                 () -> osrmClient.getEstimate(userLat, userLng, storeLat, storeLng, "foot"));
@@ -61,20 +60,13 @@ public class MacroRoutingService {
 
         CompletableFuture.allOf(walkingFuture, drivingFuture).join();
 
-        OsrmClient.TransportEstimate walkingRaw = walkingFuture.join();
-        OsrmClient.TransportEstimate drivingRaw = drivingFuture.join();
-
-        MacroRoutingResponse.TransportEstimate walking = toDto(walkingRaw);
-        MacroRoutingResponse.TransportEstimate driving = toDto(drivingRaw);
+        MacroRoutingResponse.TransportEstimate walking = toDto(walkingFuture.join());
+        MacroRoutingResponse.TransportEstimate driving = toDto(drivingFuture.join());
 
         logger.info("Macro-routing result: walking={} driving={}", walking, driving);
         return new MacroRoutingResponse(walking, driving);
     }
 
-    /**
-     * Uses ST_Centroid of the store's boundary_polygon as the entrance point.
-     * Returns [lat, lng] or an empty array if the store doesn't exist.
-     */
     private double[] fetchStoreEntrance(String storeId) {
         String sql = "SELECT ST_Y(ST_Centroid(boundary_polygon)) AS lat, " +
                      "ST_X(ST_Centroid(boundary_polygon)) AS lng " +
@@ -83,8 +75,8 @@ public class MacroRoutingService {
         UUID uuid;
         try {
             uuid = UUID.fromString(storeId);
-        } catch (IllegalArgumentException _) {
-            logger.warn("Invalid storeId UUID: {}", storeId.replaceAll("[\r\n]", ""));
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid storeId format");
             return new double[0];
         }
 
@@ -95,17 +87,15 @@ public class MacroRoutingService {
         Object lngObj = rows.get(0).get("lng");
 
         if (!(latObj instanceof Number) || !(lngObj instanceof Number)) {
-            logger.warn("Centroid extraction returned null or non-number for storeId={}", uuid);
+            logger.warn("Centroid extraction returned null or non-number");
             return new double[0];
         }
 
-        double lat = ((Number) latObj).doubleValue();
-        double lng = ((Number) lngObj).doubleValue();
-        return new double[]{lat, lng};
+        return new double[]{((Number) latObj).doubleValue(), ((Number) lngObj).doubleValue()};
     }
 
     private MacroRoutingResponse.TransportEstimate toDto(OsrmClient.TransportEstimate raw) {
         if (raw == null) return null;
-        return new MacroRoutingResponse.TransportEstimate(raw.distanceM(), raw.durationSeconds());
+        return new MacroRoutingResponse.TransportEstimate(raw.distanceM(), raw.durationSeconds(), raw.polyline());
     }
 }

--- a/src/test/java/com/p2ps/client/OsrmClientTest.java
+++ b/src/test/java/com/p2ps/client/OsrmClientTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -101,19 +103,20 @@ class OsrmClientTest {
     @Test
     void getEstimate_shouldUseFullOverviewInUrl() {
         String json = """
-            {
-              "code": "Ok",
-              "routes": [{ "distance": 100.0, "duration": 60.0, "geometry": "xyz" }]
-            }
-            """;
+        {
+          "code": "Ok",
+          "routes": [{ "distance": 100.0, "duration": 60.0, "geometry": "xyz" }]
+        }
+        """;
         when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(json);
 
         client.getEstimate(47.15, 27.58, 47.16, 27.59, "foot");
 
-       verify(restTemplate).getForObject(
-        argThat(url -> url.toString().contains("overview=full") && url.toString().contains("geometries=polyline")),
-        eq(String.class)
-);
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate).getForObject(urlCaptor.capture(), eq(String.class));
+        String capturedUrl = urlCaptor.getValue();
+        assertTrue(capturedUrl.contains("overview=full"));
+        assertTrue(capturedUrl.contains("geometries=polyline"));
     }
 
     @Test

--- a/src/test/java/com/p2ps/client/OsrmClientTest.java
+++ b/src/test/java/com/p2ps/client/OsrmClientTest.java
@@ -18,12 +18,33 @@ class OsrmClientTest {
     void setUp() {
         restTemplate = mock(RestTemplate.class);
         client = new OsrmClient(restTemplate, new ObjectMapper());
-        // Set base URL via ReflectionTestUtils instead of manual reflection
         ReflectionTestUtils.setField(client, "osrmBaseUrl", "http://mock-osrm");
     }
 
     @Test
-    void getEstimate_shouldReturnEstimateOnOkResponse() throws Exception {
+    void getEstimate_shouldReturnEstimateWithPolylineOnOkResponse() {
+        String json = """
+            {
+              "code": "Ok",
+              "routes": [{
+                "distance": 850.5,
+                "duration": 612.3,
+                "geometry": "abcdefghij_polyline"
+              }]
+            }
+            """;
+        when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(json);
+
+        OsrmClient.TransportEstimate result = client.getEstimate(47.15, 27.58, 47.16, 27.59, "foot");
+
+        assertNotNull(result);
+        assertEquals(850.5, result.distanceM(), 0.01);
+        assertEquals(612.3, result.durationSeconds(), 0.01);
+        assertEquals("abcdefghij_polyline", result.polyline());
+    }
+
+    @Test
+    void getEstimate_shouldReturnNullPolylineWhenGeometryMissing() {
         String json = """
             {
               "code": "Ok",
@@ -35,8 +56,7 @@ class OsrmClientTest {
         OsrmClient.TransportEstimate result = client.getEstimate(47.15, 27.58, 47.16, 27.59, "foot");
 
         assertNotNull(result);
-        assertEquals(850.5, result.distanceM(), 0.01);
-        assertEquals(612.3, result.durationSeconds(), 0.01);
+        assertNull(result.polyline());
     }
 
     @Test
@@ -79,9 +99,28 @@ class OsrmClientTest {
     }
 
     @Test
-    void transportEstimate_recordShouldStoreValues() {
-        OsrmClient.TransportEstimate estimate = new OsrmClient.TransportEstimate(100.0, 60.0);
+    void getEstimate_shouldUseFullOverviewInUrl() {
+        String json = """
+            {
+              "code": "Ok",
+              "routes": [{ "distance": 100.0, "duration": 60.0, "geometry": "xyz" }]
+            }
+            """;
+        when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(json);
+
+        client.getEstimate(47.15, 27.58, 47.16, 27.59, "foot");
+
+       verify(restTemplate).getForObject(
+        argThat(url -> url.toString().contains("overview=full") && url.toString().contains("geometries=polyline")),
+        eq(String.class)
+);
+    }
+
+    @Test
+    void transportEstimate_recordShouldStoreAllValues() {
+        OsrmClient.TransportEstimate estimate = new OsrmClient.TransportEstimate(100.0, 60.0, "test_polyline");
         assertEquals(100.0, estimate.distanceM(), 0.001);
         assertEquals(60.0, estimate.durationSeconds(), 0.001);
+        assertEquals("test_polyline", estimate.polyline());
     }
 }

--- a/src/test/java/com/p2ps/controller/RoutingControllerTest.java
+++ b/src/test/java/com/p2ps/controller/RoutingControllerTest.java
@@ -203,8 +203,9 @@ class RoutingControllerTest {
     @Test
     void getMacroEstimates_shouldReturn200WithEstimates() {
         MacroRoutingResponse macroResponse = new MacroRoutingResponse(
-                new MacroRoutingResponse.TransportEstimate(850.0, 612.0),
-                new MacroRoutingResponse.TransportEstimate(1200.0, 145.0)
+                new MacroRoutingResponse.TransportEstimate(850.0, 612.0, null),
+                new MacroRoutingResponse.TransportEstimate(1200.0, 145.0, null)
+
         );
         when(macroRoutingService.getEstimates(47.15, 27.58, "store-uuid")).thenReturn(macroResponse);
 

--- a/src/test/java/com/p2ps/service/MacroRoutingServiceTest.java
+++ b/src/test/java/com/p2ps/service/MacroRoutingServiceTest.java
@@ -31,12 +31,12 @@ class MacroRoutingServiceTest {
     }
 
     @Test
-    void getEstimates_shouldReturnBothEstimatesWhenOsrmResponds() {
+    void getEstimates_shouldReturnBothEstimatesWithPolylineWhenOsrmResponds() {
         mockStoreEntrance(47.156, 27.587);
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("foot")))
-                .thenReturn(new OsrmClient.TransportEstimate(850.0, 612.0));
+                .thenReturn(new OsrmClient.TransportEstimate(850.0, 612.0, "walking_polyline"));
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("car")))
-                .thenReturn(new OsrmClient.TransportEstimate(1200.0, 145.0));
+                .thenReturn(new OsrmClient.TransportEstimate(1200.0, 145.0, "driving_polyline"));
 
         MacroRoutingResponse response = service.getEstimates(47.15, 27.58, STORE_ID);
 
@@ -45,8 +45,10 @@ class MacroRoutingServiceTest {
         assertNotNull(response.getDriving());
         assertEquals(850.0, response.getWalking().getDistanceM(), 0.001);
         assertEquals(612.0, response.getWalking().getDurationSeconds(), 0.001);
+        assertEquals("walking_polyline", response.getWalking().getPolyline());
         assertEquals(1200.0, response.getDriving().getDistanceM(), 0.001);
         assertEquals(145.0, response.getDriving().getDurationSeconds(), 0.001);
+        assertEquals("driving_polyline", response.getDriving().getPolyline());
     }
 
     @Test
@@ -65,7 +67,7 @@ class MacroRoutingServiceTest {
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("foot")))
                 .thenReturn(null);
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("car")))
-                .thenReturn(new OsrmClient.TransportEstimate(1200.0, 145.0));
+                .thenReturn(new OsrmClient.TransportEstimate(1200.0, 145.0, "driving_polyline"));
 
         MacroRoutingResponse response = service.getEstimates(47.15, 27.58, STORE_ID);
 
@@ -78,7 +80,7 @@ class MacroRoutingServiceTest {
     void getEstimates_shouldReturnNullDrivingWhenOsrmFailsForCar() {
         mockStoreEntrance(47.156, 27.587);
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("foot")))
-                .thenReturn(new OsrmClient.TransportEstimate(850.0, 612.0));
+                .thenReturn(new OsrmClient.TransportEstimate(850.0, 612.0, "walking_polyline"));
         when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("car")))
                 .thenReturn(null);
 
@@ -99,6 +101,27 @@ class MacroRoutingServiceTest {
 
         verify(osrmClient).getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("foot"));
         verify(osrmClient).getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), eq("car"));
+    }
+
+    @Test
+    void getEstimates_shouldReturnNullForInvalidStoreIdFormat() {
+        MacroRoutingResponse response = service.getEstimates(47.15, 27.58, "not-a-uuid");
+
+        assertNull(response);
+        verifyNoInteractions(osrmClient);
+    }
+
+    @Test
+    void getEstimates_shouldHandleNullPolylineFromOsrm() {
+        mockStoreEntrance(47.156, 27.587);
+        when(osrmClient.getEstimate(anyDouble(), anyDouble(), anyDouble(), anyDouble(), any()))
+                .thenReturn(new OsrmClient.TransportEstimate(850.0, 612.0, null));
+
+        MacroRoutingResponse response = service.getEstimates(47.15, 27.58, STORE_ID);
+
+        assertNotNull(response);
+        assertNotNull(response.getWalking());
+        assertNull(response.getWalking().getPolyline());
     }
 
     private void mockStoreEntrance(double lat, double lng) {


### PR DESCRIPTION
Previously, the /api/routing/macro endpoint returned only distance and duration estimates for walking and driving to the store entrance. The route was displayed as a straight line on the map, which is not realistic.
This PR updates the endpoint to also return the encoded polyline geometry from OSRM, which contains the actual road path including all turns and curves. The frontend can decode this string using a standard polyline library and draw the real route on the map.
Changes:

OsrmClient — updated the OSRM request to use overview=full&geometries=polyline instead of overview=false. The geometry field is now extracted from the response and included in TransportEstimate.
MacroRoutingResponse.TransportEstimate — added a polyline field containing the encoded polyline string.
MacroRoutingService — passes the polyline through the toDto conversion.
Updated tests for OsrmClient and MacroRoutingService to cover the new field, including the null case when OSRM does not return geometry.

How to test:
GET /api/routing/macro?userLat=47.156&userLng=27.587&storeId=<uuid>
The response now includes a polyline field in both walking and driving objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Macro-routing estimates now include encoded polyline geometry data, enabling accurate rendering of actual road routes on maps instead of straight-line approximations.

* **Documentation**
  * Updated documentation to clarify distance calculations reflect actual road routes and explain polyline field availability (may be null if unavailable from routing service).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/P2P-Shopping/server/pull/261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->